### PR TITLE
fix: ensure f5xc-pipeline hook always runs on every commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,11 +31,12 @@ repos:
     hooks:
       # F5 XC API Enrichment Pipeline
       # Runs the unified pipeline and stages enriched specs
+      # Always runs first to ensure generated output is validated by subsequent hooks
       - id: f5xc-pipeline
         name: F5 XC API Enrichment Pipeline
         entry: scripts/hooks/pre-commit-pipeline.sh
         language: script
-        files: ^(specs/original/.*\.json|scripts/.*\.py|config/.*\.yaml)$
+        always_run: true
         pass_filenames: false
         stages: [pre-commit]
         verbose: true

--- a/docs/specifications/api/index.json
+++ b/docs/specifications/api/index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.9",
-  "timestamp": "2025-12-20T05:37:48.040888+00:00",
+  "timestamp": "2025-12-20T05:50:42.078167+00:00",
   "specifications": [
     {
       "domain": "ai_intelligence",


### PR DESCRIPTION
## Summary

Adds `always_run: true` to the f5xc-pipeline hook so it executes on every pre-commit, regardless of which files are staged.

## Problem

Previously the hook had a `files:` pattern that would skip execution when no matching files were staged:
```
F5 XC API Enrichment Pipeline........................(no files to check)Skipped
```

## Solution

- Added `always_run: true` to the hook configuration
- Removed the `files:` pattern (not needed with always_run)

## Result

Now the pipeline always runs first:
```
F5 XC API Enrichment Pipeline............................................Passed
```

This ensures generated/enriched specs are always validated by subsequent linting hooks.

---
🤖 Generated with Claude Code