### PR TITLE
fix: update API documentation viewers to use domain specs

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -264,7 +264,7 @@
             <div class="footer-links">
                 <a href="https://docs.cloud.f5.com" target="_blank">Official Documentation</a>
                 <a href="https://github.com/robinmordasiewicz/f5xc-api-enriched" target="_blank">GitHub Repository</a>
-                <a href="./specifications/api/openapi.json" target="_blank">Download OpenAPI Spec</a>
+                <a href="./specifications/api/index.json" target="_blank">API Spec Index</a>
             </div>
             <p class="footer-text">
                 Enriched API specifications for F5 Distributed Cloud Services

--- a/docs/scalar/index.html
+++ b/docs/scalar/index.html
@@ -25,6 +25,7 @@
         .header-nav {
             display: flex;
             gap: 1.5rem;
+            align-items: center;
         }
         .header-nav a {
             color: rgba(255,255,255,0.8);
@@ -33,11 +34,54 @@
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
         }
         .header-nav a:hover { color: white; }
+        .spec-selector {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+        .spec-selector label {
+            font-size: 0.9rem;
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+        }
+        .spec-selector select {
+            padding: 0.4rem 0.8rem;
+            border: 1px solid rgba(255,255,255,0.3);
+            border-radius: 4px;
+            background: rgba(255,255,255,0.1);
+            color: white;
+            font-size: 0.85rem;
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            cursor: pointer;
+        }
+        .spec-selector select:hover {
+            background: rgba(255,255,255,0.2);
+        }
+        .spec-selector select option {
+            background: #1a1a2e;
+            color: white;
+        }
+        #scalar-container {
+            min-height: calc(100vh - 60px);
+        }
+        .loading {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: calc(100vh - 60px);
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            color: #666;
+        }
     </style>
 </head>
 <body>
     <div class="header-bar">
         <span class="header-title">F5 Distributed Cloud API</span>
+        <div class="spec-selector">
+            <label for="spec-select">API Domain:</label>
+            <select id="spec-select" onchange="loadSpec(this.value)">
+                <option value="">Loading...</option>
+            </select>
+        </div>
         <nav class="header-nav">
             <a href="../">Home</a>
             <a href="../swagger-ui/">Swagger UI</a>
@@ -45,10 +89,88 @@
         </nav>
     </div>
 
-    <script
-        id="api-reference"
-        data-url="../specifications/api/openapi.json">
-    </script>
+    <div id="scalar-container">
+        <div class="loading">Loading API documentation...</div>
+    </div>
+
     <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+    <script>
+        let currentSpec = null;
+
+        function loadSpec(url) {
+            if (!url) return;
+            currentSpec = url;
+
+            // Clear and recreate container
+            const container = document.getElementById('scalar-container');
+            container.innerHTML = '<div class="loading">Loading API documentation...</div>';
+
+            // Create new script element for Scalar
+            const script = document.createElement('script');
+            script.id = 'api-reference';
+            script.dataset.url = url;
+            container.innerHTML = '';
+            container.appendChild(script);
+
+            // Reinitialize Scalar
+            if (window.Scalar) {
+                window.Scalar.createApiReference('#scalar-container', {
+                    spec: { url: url }
+                });
+            }
+        }
+
+        // Initialize on page load
+        window.onload = async function() {
+            const select = document.getElementById('spec-select');
+            let defaultSpec = null;
+
+            try {
+                const response = await fetch('../specifications/api/index.json');
+                if (response.ok) {
+                    const index = await response.json();
+                    select.innerHTML = '';
+
+                    index.specifications.forEach((spec, idx) => {
+                        const option = document.createElement('option');
+                        option.value = `../specifications/api/${spec.file}`;
+                        option.textContent = `${spec.title} (${spec.path_count} endpoints)`;
+                        select.appendChild(option);
+
+                        // Use load_balancer as default, or first spec
+                        if (spec.domain === 'load_balancer') {
+                            defaultSpec = option.value;
+                            option.selected = true;
+                        } else if (idx === 0 && !defaultSpec) {
+                            defaultSpec = option.value;
+                        }
+                    });
+
+                    // Load default spec
+                    if (defaultSpec) {
+                        const container = document.getElementById('scalar-container');
+                        container.innerHTML = '';
+
+                        const script = document.createElement('script');
+                        script.id = 'api-reference';
+                        script.dataset.url = defaultSpec;
+                        container.appendChild(script);
+
+                        // Initialize Scalar
+                        if (window.Scalar) {
+                            window.Scalar.createApiReference('#scalar-container', {
+                                spec: { url: defaultSpec }
+                            });
+                        }
+                    }
+                }
+            } catch (e) {
+                console.error('Could not load spec index:', e);
+                select.innerHTML = '<option value="">Error loading specs</option>';
+                document.getElementById('scalar-container').innerHTML =
+                    '<div class="loading">Error loading API specifications</div>';
+            }
+        };
+    </script>
 </body>
 </html>

--- a/docs/specifications/api/index.json
+++ b/docs/specifications/api/index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.9",
-  "timestamp": "2025-12-20T05:50:42.078167+00:00",
+  "timestamp": "2025-12-20T05:59:49.113322+00:00",
   "specifications": [
     {
       "domain": "ai_intelligence",

--- a/docs/swagger-ui/index.html
+++ b/docs/swagger-ui/index.html
@@ -123,9 +123,9 @@
     </div>
 
     <div class="spec-selector">
-        <label for="spec-select">Select API:</label>
+        <label for="spec-select">Select API Domain:</label>
         <select id="spec-select" onchange="loadSpec(this.value)">
-            <option value="../specifications/api/openapi.json">Complete API (All Domains)</option>
+            <option value="">Loading...</option>
         </select>
     </div>
 
@@ -136,58 +136,9 @@
     <script>
         let ui = null;
 
-        function loadSpec(url) {
-            if (ui) {
-                ui = SwaggerUIBundle({
-                    url: url,
-                    dom_id: '#swagger-ui',
-                    presets: [
-                        SwaggerUIBundle.presets.apis,
-                        SwaggerUIStandalonePreset
-                    ],
-                    plugins: [
-                        SwaggerUIBundle.plugins.DownloadUrl
-                    ],
-                    layout: "StandaloneLayout",
-                    deepLinking: true,
-                    showExtensions: true,
-                    showCommonExtensions: true,
-                    tryItOutEnabled: true,
-                    requestInterceptor: function(req) {
-                        // Add auth header if token is set
-                        const token = localStorage.getItem('f5xc_api_token');
-                        if (token) {
-                            req.headers['Authorization'] = 'APIToken ' + token;
-                        }
-                        return req;
-                    }
-                });
-            }
-        }
-
-        // Initialize Swagger UI
-        window.onload = async function() {
-            // Load spec index to populate dropdown
-            try {
-                const response = await fetch('../specifications/api/index.json');
-                if (response.ok) {
-                    const index = await response.json();
-                    const select = document.getElementById('spec-select');
-
-                    index.specifications.forEach(spec => {
-                        const option = document.createElement('option');
-                        option.value = `../specifications/api/${spec.file}`;
-                        option.textContent = `${spec.title} (${spec.path_count} endpoints)`;
-                        select.appendChild(option);
-                    });
-                }
-            } catch (e) {
-                console.log('Could not load spec index');
-            }
-
-            // Initialize Swagger UI with default spec
+        function initSwaggerUI(url) {
             ui = SwaggerUIBundle({
-                url: "../specifications/api/openapi.json",
+                url: url,
                 dom_id: '#swagger-ui',
                 presets: [
                     SwaggerUIBundle.presets.apis,
@@ -210,8 +161,51 @@
                     return req;
                 }
             });
-
             window.ui = ui;
+        }
+
+        function loadSpec(url) {
+            if (url && ui) {
+                initSwaggerUI(url);
+            }
+        }
+
+        // Initialize Swagger UI
+        window.onload = async function() {
+            const select = document.getElementById('spec-select');
+            let defaultSpec = null;
+
+            // Load spec index to populate dropdown
+            try {
+                const response = await fetch('../specifications/api/index.json');
+                if (response.ok) {
+                    const index = await response.json();
+                    select.innerHTML = ''; // Clear loading option
+
+                    index.specifications.forEach((spec, idx) => {
+                        const option = document.createElement('option');
+                        option.value = `../specifications/api/${spec.file}`;
+                        option.textContent = `${spec.title} (${spec.path_count} endpoints)`;
+                        select.appendChild(option);
+
+                        // Use load_balancer as default (common use case), or first spec
+                        if (spec.domain === 'load_balancer') {
+                            defaultSpec = option.value;
+                            option.selected = true;
+                        } else if (idx === 0 && !defaultSpec) {
+                            defaultSpec = option.value;
+                        }
+                    });
+                }
+            } catch (e) {
+                console.error('Could not load spec index:', e);
+                select.innerHTML = '<option value="">Error loading specs</option>';
+            }
+
+            // Initialize Swagger UI with default spec
+            if (defaultSpec) {
+                initSwaggerUI(defaultSpec);
+            }
         };
     </script>
 </body>


### PR DESCRIPTION
## Summary

Fixes Swagger UI and Scalar documentation viewers that were failing with 404 errors because they referenced `openapi.json` which is gitignored (106MB merged file).

## Problem

Both documentation viewers at:
- https://robinmordasiewicz.github.io/f5xc-api-enriched/swagger-ui/
- https://robinmordasiewicz.github.io/f5xc-api-enriched/scalar/

Were showing "Failed to load API definition" with 404 errors for `../specifications/api/openapi.json`.

## Solution

Update both viewers to dynamically load individual domain specifications from `index.json`:

### Swagger UI
- Populates dropdown from `index.json`
- Defaults to Load Balancer API (common use case)
- Switching domains reloads the spec

### Scalar
- Added domain selector dropdown in header bar
- Dynamically initializes Scalar with selected spec
- Defaults to Load Balancer API

### Main Index
- Changed footer link from missing `openapi.json` to `index.json`

## Test Plan

- [ ] Swagger UI loads without errors
- [ ] Scalar loads without errors
- [ ] Domain switching works in both viewers
- [ ] All 23 domain specs are selectable

---
🤖 Generated with Claude Code