### PR TITLE
fix: remove workflow_dispatch, add docs HTML to triggers

### DIFF
--- a/.github/workflows/sync-and-enrich.yml
+++ b/.github/workflows/sync-and-enrich.yml
@@ -12,18 +12,7 @@ on:
       - 'config/**'
       - 'requirements.txt'
       - '.github/workflows/sync-and-enrich.yml'
-  workflow_dispatch:
-    inputs:
-      bump_type:
-        description: 'Version bump type'
-        required: false
-        default: 'auto'
-        type: choice
-        options:
-          - auto
-          - patch
-          - minor
-          - major
+      - 'docs/**/*.html'
 
 permissions:
   contents: write
@@ -140,8 +129,8 @@ jobs:
           CURRENT_VERSION=$(cat .version 2>/dev/null | tr -d '[:space:]')
           echo "current_version=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
 
-          # Determine bump type
-          BUMP_TYPE="${{ github.event.inputs.bump_type || 'auto' }}"
+          # Determine bump type (always auto since workflow_dispatch removed)
+          BUMP_TYPE="auto"
 
           # Migration check: if not semver format, start at 1.0.0
           if [[ ! "$CURRENT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then

--- a/docs/specifications/api/index.json
+++ b/docs/specifications/api/index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.9",
-  "timestamp": "2025-12-20T05:59:49.113322+00:00",
+  "timestamp": "2025-12-20T06:06:18.898296+00:00",
   "specifications": [
     {
       "domain": "ai_intelligence",


### PR DESCRIPTION
## Summary

Security improvement and automation fix for GitHub Pages deployment.

## Changes

### Removed
- `workflow_dispatch` trigger - prevents manual workflow triggering

### Added  
- `docs/**/*.html` to paths trigger - documentation HTML changes now trigger deployment

### Simplified
- `BUMP_TYPE` now always uses 'auto' (no more input option)

## Result

- Documentation changes will automatically deploy to GitHub Pages
- No manual workflow triggering allowed
- Cleaner workflow configuration

---
🤖 Generated with Claude Code