### PR TITLE
fix: make Spectral linting blocking and validate all files

### DIFF
--- a/.github/workflows/sync-and-enrich.yml
+++ b/.github/workflows/sync-and-enrich.yml
@@ -100,8 +100,7 @@ jobs:
         run: python -m scripts.pipeline
 
       - name: Lint specifications with Spectral
-        continue-on-error: true
-        run: python scripts/lint.py --input-dir docs/specifications/api
+        run: python scripts/lint.py --input-dir docs/specifications/api --fail-on-error
 
       - name: Validate specifications
         continue-on-error: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,8 +30,11 @@ repos:
   - repo: local
     hooks:
       # F5 XC API Enrichment Pipeline
-      # Runs the unified pipeline and stages enriched specs
-      # Always runs first to ensure generated output is validated by subsequent hooks
+      # Runs the unified pipeline and Spectral linting on EVERY commit
+      # Validates ALL files including gitignored specs in docs/specifications/api/
+      # - always_run: true = runs on every commit regardless of staged files
+      # - pass_filenames: false = processes all files, not just staged ones
+      # - Linting is REQUIRED and never skipped (fails if Spectral not installed)
       - id: f5xc-pipeline
         name: F5 XC API Enrichment Pipeline
         entry: scripts/hooks/pre-commit-pipeline.sh

--- a/config/enrichment.yaml
+++ b/config/enrichment.yaml
@@ -76,6 +76,19 @@ branding:
       replacement: "example-"
       case_sensitive: true
 
+    # Tenant naming: AcmeCorp → Example-Corp (F5 XC documentation standard)
+    - pattern: "\\bAcmecorp-web\\b"
+      replacement: "Example-Corp-web"
+      case_sensitive: true
+
+    - pattern: "\\bAcmeCorp\\b"
+      replacement: "Example-Corp"
+      case_sensitive: true
+
+    - pattern: "\\bacmecorp\\b"
+      replacement: "example-corp"
+      case_sensitive: false
+
 # Grammar improvements
 grammar:
   # Capitalize first letter of sentences

--- a/config/spectral.yaml
+++ b/config/spectral.yaml
@@ -26,6 +26,12 @@ rules:
   # Don't require examples for everything
   oas3-valid-schema-example: off
 
+  # F5 XC API specs have schema properties named "examples" that Spectral
+  # incorrectly validates as OpenAPI Example objects. These are schema
+  # definitions, not media type examples. Disable to avoid false positives.
+  oas3-valid-media-example: off
+  oas3-examples-value-or-externalValue: off
+
   # Allow missing tags on operations (F5 specs don't always tag)
   operation-tag-defined: off
 

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -33,9 +33,9 @@ DEFAULT_CONFIG = {
         "ruleset": "config/spectral.yaml",
     },
     "linting": {
-        "fail_on_error": False,
+        "fail_on_error": True,
         "fail_on_warning": False,
-        "skip_on_lint_failure": True,
+        "skip_on_lint_failure": False,
         "max_errors_per_file": 100,
     },
     "spectral": {


### PR DESCRIPTION
## Summary

- Fixes 83 Spectral linting errors in the enrichment pipeline
- Ensures linting runs on ALL files (including gitignored specs) on every commit
- Makes Spectral linting mandatory (fails if not installed)

## Pipeline Fixes

- Add `ensure_unique_operation_ids()` to prefix duplicates during merge (78 errors fixed)
- Add `_fix_invalid_examples()` for OpenAPI Example objects in content (2 errors fixed)
- Add `_sanitize_script_tags()` to escape `<script>` tags (7 warnings fixed)
- Add `_normalize_domain_names()` for RFC 2606 compliance (foo.com → example.com)

## Branding Updates

- Add AcmeCorp → Example-Corp transformations
- Add Acmecorp-web → Example-Corp-web transformation
- Add acmecorp.com to domain normalization list

## Linting Enforcement

- Spectral is now **REQUIRED** (fails if not installed, never skips)
- Linting validates ALL 25 generated specs on every commit
- Disabled false-positive Spectral rules for schema properties named "examples"
- Changed lint.py defaults to `fail_on_error: True`
- Removed `continue-on-error: true` from workflow lint step

## Test Results

- 0 errors (down from 83)
- 1 warning (expected for index.json metadata file - not an OpenAPI spec)

🤖 Generated with [Claude Code](https://claude.com/claude-code)