### PR TITLE
fix: remove nested regex capturing groups causing x-validation-rules corruption

### DIFF
--- a/scripts/utils/branding.py
+++ b/scripts/utils/branding.py
@@ -159,7 +159,10 @@ class BrandingTransformer:
             return pattern.sub(replacement, text)
 
         # Build a combined pattern for all protected segments
-        protected_combined = "|".join(f"({p.pattern})" for p in self._protected_patterns)
+        # NOTE: Don't wrap each pattern in () here - line 165 adds the single outer ()
+        # needed for re.split() to keep delimiters. Inner () would create nested groups
+        # causing re.split() to duplicate matches (each group level = one copy).
+        protected_combined = "|".join(p.pattern for p in self._protected_patterns)
 
         try:
             split_pattern = re.compile(f"({protected_combined})")


### PR DESCRIPTION
## Summary

Fixes a bug in `_apply_with_protection()` where nested regex capturing groups caused exponential duplication of protected patterns in the `x-validation-rules` field.

## Problem

The x-validation-rules field was being corrupted with repeated "ves.io.schema" prefixes:
```json
"x-validation-rules": {
  "ves.io.schemaves.io.schemaves.io.schemaves.io.schema...rules.message.required": "true"
}
```

## Root Cause

In `scripts/utils/branding.py` line 162, patterns were wrapped in capturing groups twice:
1. Once in the join: `f"({p.pattern})"`
2. Again in line 165: `f"({protected_combined})"`

This created nested groups `((ves\.io\.schema))`. When `re.split()` runs with nested capturing groups, each group level returns the matched text separately. With 12 branding rules iterating through `_apply_with_protection()`, the duplication compounded exponentially: 2^12 = 4096 copies.

## Fix

Removed the inner capturing groups from line 162:
```python
# Before:
protected_combined = "|".join(f"({p.pattern})" for p in self._protected_patterns)

# After:
protected_combined = "|".join(p.pattern for p in self._protected_patterns)
```

## Verification

- ✅ Pipeline runs successfully
- ✅ x-validation-rules keys now show single `ves.io.schema` prefix
- ✅ Zero corrupted patterns detected
- ✅ All pre-commit hooks pass

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)