### PR TITLE
refactor: use ETag caching for local downloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,16 +44,11 @@ Thumbs.db
 # Build artifacts
 reports/
 
-# Large combined OpenAPI spec (113MB) - use domain specs instead
-# Consumers can bundle with: npx @redocly/cli bundle docs/specifications/api/index.json -o openapi.json
-docs/specifications/api/
+# Generated specs - downloaded on demand with ETag caching
+# specs/original/ contains proprietary F5 API specs that cannot be committed
+# Run 'make download' to fetch fresh copy (uses ETag to minimize bandwidth)
 specs/
 
-# Legacy directories (from old pipeline structure)
-# Remove these after migration to simplified two-folder architecture
-specs/normalized/
-specs/merged/
-
-# Keep these:
-# specs/original/   - READ-ONLY source from F5
-# specs/enriched/   - Single output folder for all processed specs
+# Generated documentation (built by pipeline, served by GitHub Pages)
+# Consumers can bundle with: npx @redocly/cli bundle docs/specifications/api/index.json -o openapi.json
+docs/specifications/api/


### PR DESCRIPTION
## Summary

Refactors the local build process to use ETag-based caching for API spec downloads, minimizing bandwidth and delay.

## Changes

- `make download` now respects ETag caching (only downloads if source changed)
- Added `make download-force` for explicit forced downloads
- Updated `.gitignore` comments to clarify `specs/` handling
- Updated Makefile documentation with new workflow

## How It Works

1. `make download` - Checks ETag against remote, skips download if unchanged
2. `make download-force` - Always downloads fresh copy regardless of ETag
3. `make build` - Full pipeline (download → enrich → merge)

The `.etag` file stores the last downloaded version for comparison against the F5 server. This minimizes bandwidth usage during local development.

## Testing

```bash
# First download (will fetch)
$ make download
Downloading API specifications... 

# Second download (cached - skips)
$ make download
No updates available (ETag: 31b8e3-19b32abde38...)
No updates needed. Use --force to download anyway.

# Force download (always fetches)
$ make download-force
Downloading API specifications...
```

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)