### PR TITLE
feat: add workflow_dispatch trigger for manual releases

### DIFF
--- a/.github/workflows/sync-and-enrich.yml
+++ b/.github/workflows/sync-and-enrich.yml
@@ -13,6 +13,7 @@ on:
       - 'requirements.txt'
       - '.github/workflows/sync-and-enrich.yml'
       - 'docs/**/*.html'
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

Add `workflow_dispatch` trigger to enable manual triggering of the sync-and-enrich workflow.

## Changes

- Add `workflow_dispatch:` trigger to `.github/workflows/sync-and-enrich.yml`

## Benefits

- Enable manual workflow runs via `gh workflow run "Sync and Enrich API Specs"`
- Allow on-demand releases without waiting for daily schedule
- No breaking changes - workflow already handles `workflow_dispatch` events

Closes #46

---
🤖 Generated with Claude Code