### PR TITLE
fix: remove specs/original from workflow git add

### DIFF
--- a/.github/workflows/sync-and-enrich.yml
+++ b/.github/workflows/sync-and-enrich.yml
@@ -261,8 +261,8 @@ jobs:
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
 
-          # Only add files that are tracked (specs are gitignored)
-          git add .version CHANGELOG.md .etag specs/original/
+          # Only add files that are tracked (specs/original is gitignored)
+          git add .version CHANGELOG.md .etag
 
           if git diff --staged --quiet; then
             echo "No changes to commit"


### PR DESCRIPTION
## Summary

Fix workflow failure caused by attempting to git add gitignored files.

## Problem

The workflow's "Commit changes" step tried to `git add specs/original/` but this directory is gitignored (by design - contains proprietary F5 content downloaded on demand).

## Solution

Remove `specs/original/` from the git add command. Only `.version`, `CHANGELOG.md`, and `.etag` need to be committed.

Closes #48

---
🤖 Generated with Claude Code