### PR TITLE
feat: create professional ZIP release package

### DIFF
--- a/.github/workflows/sync-and-enrich.yml
+++ b/.github/workflows/sync-and-enrich.yml
@@ -247,6 +247,53 @@ jobs:
           - ETag: ${{ needs.check-updates.outputs.etag || 'N/A' }}
           EOF
 
+      - name: Create release package
+        id: package
+        if: steps.version.outputs.has_changes == 'true'
+        run: |
+          VERSION="${{ steps.version.outputs.new_version }}"
+          RELEASE_DIR="release-package"
+          ZIP_NAME="f5xc-api-specs-v${VERSION}.zip"
+
+          mkdir -p "$RELEASE_DIR/domains"
+
+          # Copy master specs
+          cp docs/specifications/api/openapi.json "$RELEASE_DIR/"
+
+          # Convert JSON to YAML
+          python -c "
+          import json
+          import yaml
+
+          with open('docs/specifications/api/openapi.json', 'r') as f:
+              spec = json.load(f)
+
+          with open('$RELEASE_DIR/openapi.yaml', 'w') as f:
+              yaml.dump(spec, f, default_flow_style=False, allow_unicode=True, sort_keys=False)
+          "
+
+          # Copy domain specs
+          for f in docs/specifications/api/*.json; do
+            basename_f=$(basename "$f")
+            if [ "$basename_f" != "openapi.json" ] && [ "$basename_f" != "index.json" ]; then
+              cp "$f" "$RELEASE_DIR/domains/"
+            fi
+          done
+
+          # Copy metadata
+          cp docs/specifications/api/index.json "$RELEASE_DIR/"
+          cp CHANGELOG.md "$RELEASE_DIR/"
+
+          # Generate README from template (replace placeholders)
+          sed "s/{VERSION}/$VERSION/g; s/{DATE}/$(date -u +%Y-%m-%d)/g" \
+            release/README.md > "$RELEASE_DIR/README.md"
+
+          # Create ZIP
+          cd "$RELEASE_DIR" && zip -r "../$ZIP_NAME" .
+
+          echo "zip_name=$ZIP_NAME" >> "$GITHUB_OUTPUT"
+          echo "::notice::Created release package: $ZIP_NAME"
+
       - name: Upload docs artifact for deployment
         if: steps.version.outputs.has_changes == 'true'
         uses: actions/upload-artifact@v4
@@ -289,6 +336,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION="${{ steps.version.outputs.new_version }}"
+          ZIP_NAME="${{ steps.package.outputs.zip_name }}"
 
           # Check if release already exists
           if gh release view "v$VERSION" >/dev/null 2>&1; then
@@ -296,12 +344,11 @@ jobs:
             exit 0
           fi
 
-          # Create release with enriched specs (files exist locally, just gitignored)
+          # Create release with ZIP package
           gh release create "v$VERSION" \
-            --title "API Specs v$VERSION" \
+            --title "F5 XC API Specs v$VERSION" \
             --notes-file CHANGELOG.md \
-            docs/specifications/api/openapi.json \
-            docs/specifications/api/index.json
+            "$ZIP_NAME"
 
   deploy-docs:
     name: Deploy Documentation

--- a/release/README.md
+++ b/release/README.md
@@ -1,0 +1,137 @@
+# F5 Distributed Cloud API Specifications
+
+Enriched OpenAPI 3.0 specifications for F5 Distributed Cloud (XC) platform.
+
+## Quick Start
+
+### Validate the Specification
+
+```bash
+npx @redocly/cli lint openapi.json
+```
+
+### Generate a Python Client
+
+```bash
+npx @openapitools/openapi-generator-cli generate \
+  -i openapi.json -g python -o ./python-client
+```
+
+### Generate a Go Client
+
+```bash
+npx @openapitools/openapi-generator-cli generate \
+  -i openapi.json -g go -o ./go-client
+```
+
+### Import to Postman
+
+1. Open Postman
+2. Click **Import** → **File**
+3. Select `openapi.json` or any domain-specific spec from `domains/`
+
+### Import to Insomnia
+
+1. Open Insomnia
+2. Click **Import/Export** → **Import Data**
+3. Select `openapi.json`
+
+## Contents
+
+| File | Description |
+|------|-------------|
+| `openapi.json` | Master specification (all domains combined) |
+| `openapi.yaml` | Master specification in YAML format |
+| `index.json` | Metadata and inventory of all specifications |
+| `domains/` | Individual domain specifications for selective import |
+
+## Domain Specifications
+
+The `domains/` directory contains individual specifications organized by functional area:
+
+| Domain | Description |
+|--------|-------------|
+| `api_security.json` | API security and protection features |
+| `applications.json` | Application delivery and management |
+| `bigip.json` | BIG-IP integration and management |
+| `billing.json` | Billing and usage tracking |
+| `cdn.json` | Content delivery network configuration |
+| `config.json` | Configuration management |
+| `identity.json` | Identity and access management |
+| `infrastructure.json` | Infrastructure provisioning |
+| `infrastructure_protection.json` | DDoS and infrastructure protection |
+| `integrations.json` | Third-party integrations |
+| `load_balancer.json` | Load balancing configuration |
+| `networking.json` | Network connectivity and routing |
+| `nginx.json` | NGINX management |
+| `observability.json` | Monitoring, logging, and metrics |
+| `operations.json` | Operational tasks and automation |
+| `security.json` | Security policies and WAF |
+| `service_mesh.json` | Service mesh configuration |
+| `shape_security.json` | Bot defense and fraud protection |
+| `subscriptions.json` | Subscription management |
+| `tenant_management.json` | Multi-tenant administration |
+| `vpn.json` | VPN and secure connectivity |
+
+## Version Information
+
+- **Version**: {VERSION}
+- **Release Date**: {DATE}
+- **OpenAPI Version**: 3.0.3
+
+## Enrichment Applied
+
+These specifications have been enriched with:
+
+- **Acronym Normalization**: 100+ technical terms standardized
+- **Grammar Improvements**: Enhanced descriptions and summaries
+- **Branding Updates**: Volterra references updated to F5 Distributed Cloud
+- **Schema Validation**: All specifications validated with Spectral linter
+
+## Usage Tips
+
+### Working with Large Specs
+
+The master `openapi.json` is comprehensive (~18MB). For faster tooling:
+
+```bash
+# Use a specific domain instead of the full spec
+npx @openapitools/openapi-generator-cli generate \
+  -i domains/load_balancer.json -g python -o ./lb-client
+```
+
+### Bundling for Distribution
+
+```bash
+npx @redocly/cli bundle openapi.json -o bundled-openapi.json
+```
+
+### Converting Formats
+
+```bash
+# JSON to YAML (already included as openapi.yaml)
+npx @redocly/cli bundle openapi.json -o openapi.yaml
+
+# Split into multiple files
+npx @redocly/cli split openapi.json --outDir ./split-specs
+```
+
+## Legal Notice
+
+These API specifications are derived from F5 Distributed Cloud's publicly
+available OpenAPI documentation. The underlying API specification content
+is the intellectual property of F5, Inc.
+
+This enriched version includes automated improvements such as grammar
+corrections, acronym normalization, and branding updates. These enrichments
+are provided as-is for developer convenience.
+
+For official API documentation and terms of use, please refer to:
+
+- [F5 Distributed Cloud Documentation](https://docs.cloud.f5.com/)
+- [F5 Terms of Service](https://www.f5.com/company/policies/terms-of-service)
+
+## Source
+
+- **Repository**: [f5xc-api-enriched](https://github.com/robinmordasiewicz/f5xc-api-enriched)
+- **Documentation**: [GitHub Pages](https://robinmordasiewicz.github.io/f5xc-api-enriched/)


### PR DESCRIPTION
## Summary

Refactors the release process to create a professional, structured ZIP archive following industry best practices from Stripe, Twilio, and GitHub OpenAPI repositories.

### Changes

- **Create `release/README.md` template** with:
  - Quick start examples (validation, client generation, Postman/Insomnia import)
  - Domain specifications table with descriptions
  - Version placeholders (`{VERSION}`, `{DATE}`) for build-time substitution
  - Legal notice referencing F5's intellectual property

- **Update workflow** to create ZIP release package:
  - Package structure: `openapi.json`, `openapi.yaml`, `index.json`, `domains/`
  - Include all 23 domain specs in `domains/` subdirectory
  - Generate YAML format from JSON using PyYAML
  - Include README and CHANGELOG in package

### Release Package Structure

```
f5xc-api-specs-v1.0.x.zip
├── README.md          # Usage, quick start, domain descriptions
├── CHANGELOG.md       # Version history
├── openapi.json       # Master combined spec (~18MB)
├── openapi.yaml       # Master spec in YAML format
├── index.json         # Metadata and inventory
└── domains/           # Individual domain specs
    ├── api_security.json
    ├── applications.json
    ├── load_balancer.json
    └── ... (23 total)
```

### Benefits

| Current | Proposed |
|---------|----------|
| 2 loose JSON files | Single organized ZIP archive |
| No documentation | README with usage examples |
| Master spec only | All 23 domain specs included |
| JSON only | Both JSON and YAML formats |

### Legal Note

No separate LICENSE file is included because the underlying API specification content is F5's intellectual property. A legal notice in the README references the official F5 documentation and terms of service.

## Test Plan

- [ ] Verify workflow YAML syntax is valid
- [ ] Verify README template placeholders work correctly
- [ ] Verify ZIP creation includes all expected files
- [ ] Verify YAML conversion produces valid output

🤖 Generated with Claude Code