### PR TITLE
fix: skip constraint analysis when openapi.json not available

### DIFF
--- a/.github/workflows/sync-and-enrich.yml
+++ b/.github/workflows/sync-and-enrich.yml
@@ -108,6 +108,14 @@ jobs:
             echo "has_discovery=false" >> "$GITHUB_OUTPUT"
             echo "No discovery data - running standard enrichment"
           fi
+          # Check for full openapi.json (required for constraint analysis)
+          # This is gitignored due to 26MB size, only available when run locally
+          if [ -f "specs/discovered/openapi.json" ]; then
+            echo "has_full_discovery=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_full_discovery=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Full discovery openapi.json not available - constraint analysis skipped"
+          fi
 
       - name: Run enrichment pipeline
         run: python -m scripts.pipeline
@@ -115,7 +123,7 @@ jobs:
           DISCOVERY_ENRICHMENT_ENABLED: ${{ steps.check-discovery.outputs.has_discovery }}
 
       - name: Generate constraint analysis report
-        if: steps.check-discovery.outputs.has_discovery == 'true'
+        if: steps.check-discovery.outputs.has_full_discovery == 'true'
         run: python -m scripts.analyze_constraints
 
       - name: Lint specifications with Spectral


### PR DESCRIPTION
## Summary

Fixes the CI failure introduced in #53 where constraint analysis was looking for `specs/discovered/openapi.json` which is gitignored due to its 26MB size.

### Changes

- Added `has_full_discovery` output to check specifically for `openapi.json`
- Constraint analysis now only runs when full discovery data is available (locally)
- Discovery enrichment still works based on `session.json` metadata

### CI Behavior

- **With session.json only**: Discovery enrichment enabled, constraint analysis skipped
- **With session.json + openapi.json**: Full discovery features including constraint analysis

Fixes workflow run: https://github.com/robinmordasiewicz/f5xc-api-enriched/actions/runs/20399547325

🤖 Generated with [Claude Code](https://claude.com/claude-code)