### PR TITLE
feat: add f5xcctl CLI tool branding transformations

### DIFF
--- a/config/enrichment.yaml
+++ b/config/enrichment.yaml
@@ -16,7 +16,7 @@ paths:
   reports: "reports"
 
 # Branding transformations
-# Synchronized with f5xc-api-mcp project for compatibility
+# Synchronized with f5xc-api-mcp project and f5xcctl CLI tool for compatibility
 branding:
   # Protected patterns - these should NOT be transformed
   # Used to preserve API URLs, console URLs, and schema references
@@ -70,6 +70,24 @@ branding:
       replacement: "F5 XC"
       case_sensitive: false
       context: "description"
+
+    # f5xcctl CLI tool branding (for f5xcctl command-line tool)
+    - pattern: "\\bvesctl\\b"
+      replacement: "f5xcctl"
+      case_sensitive: true
+
+    - pattern: "\\bVesctl\\b"
+      replacement: "F5xcctl"
+      case_sensitive: true
+
+    - pattern: "\\bVESCTL\\b"
+      replacement: "F5XCCTL"
+      case_sensitive: true
+
+    # Environment variable transformations for f5xcctl
+    - pattern: "\\bVES_([A-Z_]+)\\b"
+      replacement: "F5XC_\\1"
+      case_sensitive: true
 
     # Naming convention: my- prefix → example- prefix (MCP compatibility)
     - pattern: "\\bmy-"


### PR DESCRIPTION
## Summary

Add f5xcctl CLI tool branding transformations to the API spec enrichment pipeline.

### Changes

Add new branding rules to enrich API specifications for compatibility with f5xcctl:
- `vesctl` → `f5xcctl` (all case variations: Vesctl→F5xcctl, VESCTL→F5XCCTL)
- `VES_*` → `F5XC_*` (environment variable pattern matching)

### Files Changed
- `config/enrichment.yaml` - Added f5xcctl branding rules to replacements

### Impact

When enriched API specs are downloaded by f5xcctl, environment variable and CLI tool references will automatically be branded as F5XC_ and f5xcctl, providing consistent documentation.

### Testing
- Branding transformer will process all target fields (description, title, x-displayname, x-ves-example)
- Follows protected pattern rules (won't transform URLs, schema refs, etc.)
- No manual intervention required during spec enrichment