### PR TITLE
fix: make Spectral linting strict and fix $ref sibling corruption

### DIFF
--- a/.github/workflows/sync-and-enrich.yml
+++ b/.github/workflows/sync-and-enrich.yml
@@ -129,7 +129,7 @@ jobs:
         run: python -m scripts.analyze_constraints
 
       - name: Lint specifications with Spectral
-        run: python scripts/lint.py --input-dir docs/specifications/api --fail-on-error
+        run: python scripts/lint.py --input-dir docs/specifications/api --fail-on-error --fail-on-warning
 
       - name: Validate specifications
         continue-on-error: true

--- a/scripts/hooks/pre-commit-pipeline.sh
+++ b/scripts/hooks/pre-commit-pipeline.sh
@@ -72,11 +72,11 @@ if ! command -v spectral &> /dev/null; then
     exit 1
 fi
 
-echo -e "${YELLOW}Executing: $PYTHON scripts/lint.py --input-dir docs/specifications/api --fail-on-error${NC}"
+echo -e "${YELLOW}Executing: $PYTHON scripts/lint.py --input-dir docs/specifications/api --fail-on-error --fail-on-warning${NC}"
 echo -e "${YELLOW}Note: Validating ALL 25 generated specs (including gitignored files)${NC}"
 
-# Run linting on ALL files in the directory - fail on errors to ensure clean specs
-if $PYTHON scripts/lint.py --input-dir docs/specifications/api --fail-on-error; then
+# Run linting on ALL files in the directory - fail on errors AND warnings to ensure clean specs
+if $PYTHON scripts/lint.py --input-dir docs/specifications/api --fail-on-error --fail-on-warning; then
     echo -e "${GREEN}Spectral linting passed (all files validated).${NC}"
 else
     LINT_EXIT_CODE=$?

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -279,8 +279,8 @@ def lint_all_specs(
     """
     stats = LintStats()
 
-    # Find all JSON spec files
-    spec_files = sorted(input_dir.glob("*.json"))
+    # Find all JSON spec files (exclude index.json which is metadata, not OpenAPI)
+    spec_files = sorted(f for f in input_dir.glob("*.json") if f.name != "index.json")
     if not spec_files:
         console.print(f"[yellow]No specification files found in {input_dir}[/yellow]")
         return stats

--- a/scripts/utils/discovery_enricher.py
+++ b/scripts/utils/discovery_enricher.py
@@ -352,6 +352,11 @@ class DiscoveryEnricher:
             prop_path: Full path for lookup
             discovered_constraints: Discovered constraints lookup
         """
+        # OpenAPI 3.0: $ref cannot have sibling properties (except description/summary)
+        # Skip enrichment for schemas that use $ref to avoid invalid specs
+        if "$ref" in prop_schema:
+            return
+
         # confidence_threshold and min_sample_size reserved for future statistical validation
         _ = self.config.get("constraints", {}).get("confidence_threshold", 0.8)
         _ = self.config.get("constraints", {}).get("min_sample_size", 5)


### PR DESCRIPTION
## Summary

- **Fix $ref sibling corruption**: Discovery enricher was adding constraint properties (maxLength, x-field-mutability, etc.) to schemas containing `$ref`, violating OpenAPI 3.0 spec
- **Exclude index.json from linting**: Metadata file was causing spurious "unrecognized-format" warnings  
- **Make warnings blocking**: Both CI workflow and pre-commit now fail on warnings, ensuring identical strictness

## Root Cause Analysis

When discovery enrichment was enabled (`DISCOVERY_ENRICHMENT_ENABLED=true`), the workflow showed 622 warnings while local builds showed 1. Investigation revealed:

1. **207 `no-$ref-siblings` warnings**: Discovery enricher added constraints to `$ref` schemas
2. **1 `unrecognized-format` warning**: index.json (metadata) was being linted as OpenAPI spec
3. **Inconsistent enforcement**: `--fail-on-warning` flag was missing from both environments

## Changes

| File | Change |
|------|--------|
| `scripts/utils/discovery_enricher.py` | Skip enrichment on `$ref` schemas |
| `scripts/lint.py` | Exclude index.json from Spectral linting |
| `.github/workflows/sync-and-enrich.yml` | Add `--fail-on-warning` flag |
| `scripts/hooks/pre-commit-pipeline.sh` | Add `--fail-on-warning` flag |

## Result

```
Files Processed: 24
Files Passed: 24
Total Errors: 0
Total Warnings: 0
```

## Test plan

- [x] Run `make pipeline` - enrichment succeeds without $ref violations
- [x] Run `python scripts/lint.py --input-dir docs/specifications/api --fail-on-error --fail-on-warning` - 0 warnings
- [x] Pre-commit hook passes with strict validation
- [ ] GitHub Actions workflow passes with strict validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)