### PR TITLE
fix: expand release workflow change detection to include config/scripts

### DIFF
--- a/.github/workflows/sync-and-enrich.yml
+++ b/.github/workflows/sync-and-enrich.yml
@@ -149,14 +149,29 @@ jobs:
           fi
 
           # Compare with previous release or mark as changed for new runs
-          # Since specs are gitignored, we check if the original specs have changes
-          if git diff --quiet -- specs/original/ .etag; then
+          # Check for changes in source specs, pipeline config, or dependencies
+          if git diff --quiet -- specs/original/ .etag scripts/ config/ requirements.txt; then
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
             echo "No changes in source specs"
             exit 0
           fi
 
           echo "has_changes=true" >> "$GITHUB_OUTPUT"
+
+          # Determine change type for semantic versioning (as bash variable for use in this script)
+          if ! git diff --quiet -- specs/original/ .etag; then
+            CHANGE_TYPE="source"
+            echo "Source spec changes detected"
+          elif ! git diff --quiet -- config/ scripts/ requirements.txt; then
+            CHANGE_TYPE="pipeline"
+            echo "Pipeline/config changes detected"
+          else
+            CHANGE_TYPE="unknown"
+            echo "Unknown change type"
+          fi
+
+          # Output change type for downstream steps
+          echo "change_type=$CHANGE_TYPE" >> "$GITHUB_OUTPUT"
 
           # Read current version
           CURRENT_VERSION=$(cat .version 2>/dev/null | tr -d '[:space:]')
@@ -172,14 +187,14 @@ jobs:
           elif [ "$BUMP_TYPE" = "auto" ]; then
             IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
 
-            # Check for major bump via commit message
+            # Check for major bump via commit message (highest priority)
             COMMIT_MSG=$(git log -1 --pretty=%B 2>/dev/null || echo "")
             if [[ "$COMMIT_MSG" == *"[major]"* ]] || \
                [[ "$COMMIT_MSG" == *"BREAKING CHANGE"* ]]; then
               NEW_VERSION="$((MAJOR + 1)).0.0"
               BUMP_TYPE="major"
-            else
-              # Check for new domain files (minor bump)
+            elif [ "$CHANGE_TYPE" = "source" ]; then
+              # Source spec changes → check for new domains (minor) or patch
               PREV_COUNT=$(git show HEAD:docs/specifications/api/index.json 2>/dev/null | \
                 jq '.specifications | length' 2>/dev/null || echo "0")
               CURR_COUNT=$(jq '.specifications | length' \
@@ -192,6 +207,16 @@ jobs:
                 NEW_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
                 BUMP_TYPE="patch"
               fi
+            elif [ "$CHANGE_TYPE" = "pipeline" ]; then
+              # Pipeline/config/dependency changes → patch bump
+              NEW_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
+              BUMP_TYPE="patch"
+              echo "::notice::Pipeline changes detected - patch bump"
+            else
+              # Fallback for unknown change types
+              NEW_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
+              BUMP_TYPE="patch"
+              echo "::warning::Unknown change type - defaulting to patch bump"
             fi
           else
             # Manual bump type


### PR DESCRIPTION
## Problem

PR #67 merged successfully but no release was created because the workflow only checks for changes in \`specs/original/\` and \`.etag\`, not changes in \`config/\`, \`scripts/\`, or \`requirements.txt\`.

**Root Cause**: Change detection logic at line 153 was too narrow.

**Impact**: Configuration changes (like PR #67's enrichment rule updates) don't trigger releases or documentation deployment.

## Solution

Expand change detection to include pipeline files and implement semantic versioning based on change type.

### Changes Made

1. **Expanded git diff check** (line 153)
   - Added: \`scripts/\`, \`config/\`, \`requirements.txt\`
   - Now detects changes in: source specs, pipeline configuration, and dependencies

2. **Added change type detection** (new section after line 159)
   - Outputs: \`change_type=source|pipeline|unknown\`
   - Differentiates between source API updates and pipeline/config updates

3. **Updated version bumping logic** (lines 180-218)
   - Source changes → check for new domains (minor/patch)
   - Pipeline changes → patch bump
   - Unknown changes → patch bump with warning
   - Breaking changes → major bump (unchanged)

## Semantic Versioning Strategy

| Change Type | Files Changed | Version Bump | Example |
|-------------|---------------|--------------|---------|
| **Pipeline changes** | \`config/\`, \`scripts/\`, \`requirements.txt\` | **Patch** | 1.0.15 → 1.0.16 |
| **Source updates** (no new domains) | \`specs/original/\`, \`.etag\` | **Patch** | 1.0.15 → 1.0.16 |
| **Source updates** (new domains) | \`specs/original/\` + domain count ↑ | **Minor** | 1.0.15 → 1.1.0 |
| **Breaking changes** | Any + \`[major]\` in commit | **Major** | 1.0.15 → 2.0.0 |

## Expected Behavior After Merge

When this fix is deployed and PR #67 config changes are processed again:
1. ✅ Detect config/enrichment.yaml changes  
2. ✅ Set \`change_type=pipeline\`
3. ✅ Bump version 1.0.15 → 1.0.16 (patch)
4. ✅ Create GitHub release v1.0.16
5. ✅ Generate CHANGELOG.md with pipeline changes noted
6. ✅ Deploy documentation to GitHub Pages

## Testing

### Pre-merge Validation
- ✅ YAML syntax (actionlint)
- ✅ All pre-commit hooks
- ✅ Spectral linting (0 errors/warnings)

### Post-merge Monitoring
- Check workflow run for v1.0.16 release creation
- Verify CHANGELOG.md includes "Pipeline/config changes"
- Confirm documentation deployment to GitHub Pages
- Validate all 24 specs accessible via Scalar UI

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)