### PR TITLE
fix: Separate data-intelligence endpoints from CDN domain

### DIFF
--- a/scripts/merge_specs.py
+++ b/scripts/merge_specs.py
@@ -167,11 +167,13 @@ DOMAIN_PATTERNS = {
         r"ike2",
         r"ike_phase",
     ],
+    "data_intelligence": [
+        r"data_delivery",
+    ],
     "cdn_and_content_delivery": [
         r"cdn_loadbalancer",
         r"cdn_cache",
         r"cdn_",
-        r"data_delivery",
     ],
     "observability_and_analytics": [
         r"synthetic_monitor",
@@ -432,18 +434,23 @@ def merge_components(
 def merge_paths(target: dict[str, Any], source: dict[str, Any], domain: str = "") -> int:
     """Merge paths from source into target, filtering by domain.
 
-    Filters out /api/cdn/ paths when domain is not cdn_and_content_delivery,
-    to prevent CDN endpoints from contaminating non-CDN domains.
+    Filters out /api/cdn/ and /api/data-intelligence/ paths when not in their
+    respective domains, to prevent endpoint contamination across domains.
     """
     source_paths = source.get("paths", {})
     target_paths = target.setdefault("paths", {})
 
     paths_added = 0
     is_cdn_domain = domain == "cdn_and_content_delivery"
+    is_data_intelligence_domain = domain == "data_intelligence"
 
     for path, path_item in source_paths.items():
         # Skip CDN paths if not merging into CDN domain
         if not is_cdn_domain and "/api/cdn/" in path:
+            continue
+
+        # Skip data-intelligence paths if not merging into data_intelligence domain
+        if not is_data_intelligence_domain and "/api/data-intelligence/" in path:
             continue
 
         if path not in target_paths:


### PR DESCRIPTION
## Summary
Moves  endpoints from the CDN domain into their own dedicated domain.

## Problem
Data Intelligence endpoints were incorrectly categorized into the  domain due to the  pattern match in the merge logic. This caused API documentation confusion and domain contamination.

## Changes
1. **New Domain**: Created  domain in 
2. **Pattern Separation**: Moved  pattern from CDN to new domain
3. **Path Filtering**: Added  path filtering logic (similar to existing  filtering)

## Results
- ✅ New domain spec: `docs/specifications/api/data_intelligence.json`
- ✅ 15 endpoints moved to Data Intelligence domain
- ✅ CDN domain now contains only CDN-specific endpoints
- ✅ Total domains: 31 → 32
- ✅ All 33 specs pass Spectral linting

## Endpoints Moved
```
/api/data-intelligence/namespaces/system/data-intelligence/addon/subscribe
/api/data-intelligence/namespaces/system/data-intelligence/addon/unsubscribe
/api/data-intelligence/namespaces/system/dataSets
/api/data-intelligence/namespaces/system/datadictionary/{dataset}
/api/data-intelligence/namespaces/system/init-request
/api/data-intelligence/namespaces/{metadata.namespace}/receivers
/api/data-intelligence/namespaces/{metadata.namespace}/receivers/{metadata.name}
/api/data-intelligence/namespaces/{namespace}/data-dictionary/datasets
/api/data-intelligence/namespaces/{namespace}/di/flowlabels
/api/data-intelligence/namespaces/{namespace}/di/summary
/api/data-intelligence/namespaces/{namespace}/receivers
/api/data-intelligence/namespaces/{namespace}/receivers/{id}/status
/api/data-intelligence/namespaces/{namespace}/receivers/{id}/test
/api/data-intelligence/namespaces/{namespace}/receivers/{name}
/api/data-intelligence/namespaces/{namespace}/suggest-values
```

## Testing
- ✅ Full pipeline execution successful
- ✅ Pre-commit hooks passed
- ✅ Spectral linting passed (33/33 specs)
- ✅ Verified CDN domain contains 0 data-intelligence endpoints
- ✅ Verified new domain contains all 15 data-intelligence endpoints

Fixes #80