### PR TITLE
fix: Move cdn_loadbalancers endpoints to CDN domain

### DIFF
--- a/scripts/merge_specs.py
+++ b/scripts/merge_specs.py
@@ -434,8 +434,8 @@ def merge_components(
 def merge_paths(target: dict[str, Any], source: dict[str, Any], domain: str = "") -> int:
     """Merge paths from source into target, filtering by domain.
 
-    Filters out /api/cdn/ and /api/data-intelligence/ paths when not in their
-    respective domains, to prevent endpoint contamination across domains.
+    Filters out /api/cdn/, /api/data-intelligence/, and /cdn_loadbalancers/
+    paths when not in their respective domains, to prevent endpoint contamination.
     """
     source_paths = source.get("paths", {})
     target_paths = target.setdefault("paths", {})
@@ -446,7 +446,7 @@ def merge_paths(target: dict[str, Any], source: dict[str, Any], domain: str = ""
 
     for path, path_item in source_paths.items():
         # Skip CDN paths if not merging into CDN domain
-        if not is_cdn_domain and "/api/cdn/" in path:
+        if not is_cdn_domain and ("/api/cdn/" in path or "/cdn_loadbalancers/" in path):
             continue
 
         # Skip data-intelligence paths if not merging into data_intelligence domain


### PR DESCRIPTION
## Summary
Moves CDN loadbalancer endpoints from app_firewall domain to cdn_and_content_delivery domain where they belong.

## Problem
API endpoints with `cdn_loadbalancers` in their paths were incorrectly categorized into `app_firewall` domain because they originated from `app_security.ves-swagger.json` file, which matched the `app_security` filename pattern.

## Solution
Implemented cross-domain spec processing that examines path content, not just filenames:
- Specs containing `/cdn_loadbalancers/` or `/api/cdn/` paths are now processed by CDN domain
- Specs containing `/api/data-intelligence/` paths are now processed by data_intelligence domain
- Path filtering ensures endpoints only appear in their correct domain

## Changes
- **CDN domain**: 19 → 64 paths (+45 paths)
- **App firewall**: Cleaned (0 cdn_loadbalancers paths)
- **Total cdn_loadbalancers paths in CDN**: 11

## Endpoints Moved (4 suggestion endpoints)
```
/api/config/namespaces/{namespace}/cdn_loadbalancers/{name}/block_client/suggestion
/api/config/namespaces/{namespace}/cdn_loadbalancers/{name}/ddos_mitigation/suggestion
/api/config/namespaces/{namespace}/cdn_loadbalancers/{name}/trust_client/suggestion
/api/config/namespaces/{namespace}/cdn_loadbalancers/{name}/waf_exclusion/suggestion
```

## Implementation
**Files Modified**:
- `scripts/pipeline.py`: Cross-domain spec grouping based on path content
- `scripts/merge_specs.py`: Path filtering for /cdn_loadbalancers/, /api/cdn/, /api/data-intelligence/

## Testing
- ✅ Full pipeline execution successful
- ✅ Pre-commit hooks passed
- ✅ Spectral linting passed (33/33 specs)
- ✅ Verified 0 cdn_loadbalancers paths in app_firewall
- ✅ Verified 11 cdn_loadbalancers paths in CDN domain

Fixes #82