### PR TITLE
feat: formalize virtual_server domain for HTTP load balancing (#104)

### DIFF
--- a/config/domain_patterns.yaml
+++ b/config/domain_patterns.yaml
@@ -193,6 +193,12 @@ domains:
       - "\\.virtual_host\\.ves"
       - "^[^.]*\\.route\\.ves"
 
+  virtual_server:
+    description: "Virtual Server and HTTP Load Balancing"
+    patterns:
+      - "http_loadbalancer"
+      - "views\\.http_loadbalancer"
+
   network:
     description: "Routing, Tunnelling, and Network Connectivity"
     patterns:

--- a/scripts/utils/domain_metadata.py
+++ b/scripts/utils/domain_metadata.py
@@ -86,6 +86,11 @@ DOMAIN_METADATA = {
         "requires_tier": "Professional",
         "domain_category": "Networking",
     },
+    "virtual_server": {
+        "is_preview": False,
+        "requires_tier": "Professional",
+        "domain_category": "Networking",
+    },
     "network": {
         "is_preview": False,
         "requires_tier": "Professional",


### PR DESCRIPTION
## Summary
Resolve resource placement ambiguity by formalizing `virtual_server` as an official domain in the configuration hierarchy. This domain is already created dynamically by the pipeline for HTTP load balancer resources, but wasn't formally defined in `domain_patterns.yaml`, creating a "shadow" domain.

## Problem
- **virtual_server** domain exists in generated output but isn't defined in configuration
- Pipeline creates it dynamically when specs contain `/http_loadbalancers/` paths
- Not registered in domain metadata, causing inconsistency
- Makes resource organization implicit rather than explicit

## Solution
Formalize the virtual_server domain through:

1. **Updated `config/domain_patterns.yaml`**
   - Added `virtual_server` domain between `virtual` and `network` domains
   - Defined patterns: "http_loadbalancer" and "views\.http_loadbalancer"
   - Includes description: "Virtual Server and HTTP Load Balancing"

2. **Updated `scripts/utils/domain_metadata.py`**
   - Added `virtual_server` metadata entry
   - is_preview: false
   - requires_tier: Professional
   - domain_category: Networking

## Benefits
- Domain now **formally defined** and discoverable
- **Idempotent**: generator produces consistent output on every run
- **Single source of truth**: configuration is authoritative
- **No spec changes**: pipeline already creates this domain; we're just formalizing it
- **Explicit structure**: resource placement is now documented and intentional

## Testing
- All 67 specifications pass linting ✓
- Pipeline executes successfully with new domain defined ✓
- YAML configuration validates correctly ✓
- Python metadata module loads without errors ✓
- Pre-commit hooks all pass ✓

## Impact
- HTTP load balancer resources now officially categorized
- API documentation properly reflects domain structure
- CLI tools can reference authoritative domain list
- No breaking changes (domain already existed in output)

Closes #104