### PR TITLE
feat: standardize domain naming by removing AND conjunctions (#103)

### DIFF
--- a/config/domain_patterns.yaml
+++ b/config/domain_patterns.yaml
@@ -120,7 +120,7 @@ domains:
       - "protocol_inspection"
       - "waf"
 
-  bot_and_threat_defense:
+  bot_defense:
     description: "Bot defense and threat intelligence"
     patterns:
       - "bot_allowlist"
@@ -350,14 +350,14 @@ domains:
       - "shape\\.safeap"
 
   # ===== K. UI & Platform Infrastructure (3 categories) =====
-  admin_console_and_ui:
+  admin:
     description: "Administration console and user interface"
     patterns:
       - "navigation_tile"
       - "ui\\."
       - "ui_static"
 
-  billing_and_usage:
+  billing:
     description: "Billing, subscription, and usage"
     patterns:
       - "billing\\."

--- a/scripts/utils/domain_metadata.py
+++ b/scripts/utils/domain_metadata.py
@@ -50,7 +50,7 @@ DOMAIN_METADATA = {
         "requires_tier": "Professional",
         "domain_category": "Security",
     },
-    "bot_and_threat_defense": {
+    "bot_defense": {
         "is_preview": False,
         "requires_tier": "Professional",
         "domain_category": "Security",
@@ -171,12 +171,12 @@ DOMAIN_METADATA = {
         "domain_category": "Security",
     },
     # UI & Platform Infrastructure
-    "admin_console_and_ui": {
+    "admin": {
         "is_preview": False,
         "requires_tier": "Standard",
         "domain_category": "Platform",
     },
-    "billing_and_usage": {
+    "billing": {
         "is_preview": False,
         "requires_tier": "Standard",
         "domain_category": "Platform",


### PR DESCRIPTION
## Summary
Standardize domain naming by removing AND conjunctions from three domain names. This improves naming consistency, follows industry best practices, and enhances CLI usability.

## Problem
Three domains violate naming conventions by using AND conjunctions:
- `bot_and_threat_defense` - unnecessarily long, breaks CLI UX
- `admin_console_and_ui` - unclear, violates naming patterns
- `billing_and_usage` - verbose, redundant

These names make API navigation harder for users and break from established naming patterns (single-word or clear multi-word descriptors).

## Solution
Programmatically rename domains in configuration:

1. **Updated `config/domain_patterns.yaml`**
   - `bot_and_threat_defense` → `bot_defense`
   - `admin_console_and_ui` → `admin`
   - `billing_and_usage` → `billing`
   - Patterns remain unchanged; resources auto-categorized

2. **Updated `scripts/utils/domain_metadata.py`**
   - Metadata entries updated to use new domain names
   - No functional changes to resource categorization
   - Metadata remains consistent (tier, category)

## Benefits
- Eliminates AND conjunctions (naming anti-pattern)
- More consistent with single-word domains (api, cdn, dns, etc.)
- Improves CLI usability (shorter commands)
- Domain names now more predictable and memorable
- **Idempotent**: Pipeline generates consistent output on each run

## Testing
- All 70 specifications pass linting validation ✓
- Pipeline executes successfully with new domain names ✓
- YAML configuration validates correctly ✓
- Python metadata module loads without errors ✓
- Pre-commit hooks all pass ✓

## Impact
- Generated specs now use new domain names (70 total)
- No resource recategorization (patterns match same resources)
- Documentation automatically reflects new naming
- CLI tools benefit from shorter, clearer domain names

## Migration Note
These are official domain names used in API docs and tools. Existing tools should update references:
- `bot_and_threat_defense` → `bot_defense`
- `admin_console_and_ui` → `admin`
- `billing_and_usage` → `billing`

Closes #103