### PR TITLE
refactor: Fix tenant naming convention - console → example-corp

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -348,6 +348,27 @@ This enables:
 4. The computed URL updates automatically to reflect your selection
 5. All API calls use the selected namespace
 
+### Tenant Naming Convention
+
+The `tenant` variable should use your **corporate identifier** rather than the service name ("console"). This prevents URL duplication in the computed server URL.
+
+**Pattern**: `https://{tenant}.console.ves.volterra.io/namespaces/{namespace}`
+
+**Examples**:
+
+- Tenant: `example-corp`, Namespace: `main` → `https://example-corp.console.ves.volterra.io/namespaces/main`
+- Tenant: `acme-inc`, Namespace: `staging` → `https://acme-inc.console.ves.volterra.io/namespaces/staging`
+- Tenant: `your-company`, Namespace: `default` → `https://your-company.console.ves.volterra.io/namespaces/default`
+
+**Naming Rules**:
+
+- Lowercase alphanumeric characters with hyphens (RFC 1123 compliant)
+- Use your organization or project identifier
+- Avoid reusing "console" or other service names
+- Examples: `example-corp`, `acme-inc`, `mycompany`, `project-name`
+
+This convention makes it clear that the tenant value should be customized for your specific F5 XC account.
+
 ### Extensible Framework
 
 The server variable framework is designed for future expansion. Current configuration file: `config/server_variables.yaml`

--- a/config/server_variables.yaml
+++ b/config/server_variables.yaml
@@ -15,11 +15,12 @@ server:
 variables:
   # Tenant variable: F5 Distributed Cloud tenant name
   tenant:
-    default: "console"
+    default: "example-corp"
     description: "Your F5 XC tenant name"
     enum:
-      - "console"
-      - "example"
+      - "example-corp"
+      - "acme-inc"
+      - "your-company"
 
   # Namespace variable: Kubernetes-style environment separation
   namespace:

--- a/scripts/merge_specs.py
+++ b/scripts/merge_specs.py
@@ -90,7 +90,7 @@ def create_base_spec(
                 "description": "F5 Distributed Cloud Console",
                 "variables": {
                     "tenant": {
-                        "default": "console",
+                        "default": "example-corp",
                         "description": "Your F5 XC tenant name",
                     },
                     "namespace": {

--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -862,7 +862,7 @@ def create_base_spec(title: str, description: str, version: str) -> dict[str, An
                 "url": "https://{tenant}.console.ves.volterra.io/namespaces/{namespace}",
                 "description": "F5 Distributed Cloud Console",
                 "variables": {
-                    "tenant": {"default": "console", "description": "Your F5 XC tenant name"},
+                    "tenant": {"default": "example-corp", "description": "Your F5 XC tenant name"},
                     "namespace": {
                         "default": "default",
                         "description": "Kubernetes-style namespace (e.g., 'default', 'production', 'staging', 'feature-123')",


### PR DESCRIPTION
## Summary

Fixes URL duplication issue in server variables by changing default tenant from 'console' to 'example-corp' (corporate identifier pattern).

## Problem

The default tenant value 'console' causes awkward URL duplication:
- Current: `https://console.console.ves.volterra.io/namespaces/main`
- Desired: `https://example-corp.console.ves.volterra.io/namespaces/main`

## Changes

- Updated `scripts/pipeline.py`: tenant default 'console' → 'example-corp'
- Updated `scripts/merge_specs.py`: tenant default 'console' → 'example-corp'
- Updated `config/server_variables.yaml`: tenant default + enum examples
- Added tenant naming convention documentation to CLAUDE.md

## Validation

✅ All 4 files staged and committed  
✅ Pre-commit hooks passed (pipeline, linting, security checks)  
✅ All 40 specs linted successfully  
✅ Pipeline validation complete  

Closes #149