### PR TITLE
feat: Add minimum configuration metadata for AI-assisted resource creation

### DIFF
--- a/config/minimum_configs.yaml
+++ b/config/minimum_configs.yaml
@@ -1,0 +1,318 @@
+version: "1.0.0"
+description: "Minimum configuration definitions for F5 XC resources"
+
+# Global settings for enrichment
+global:
+  extension_prefix: "x-ves"
+  preserve_existing: true
+  auto_detect_domain: true
+
+# Target resource definitions (5 priority resources for Issue #152)
+resources:
+  # ============================================================================
+  # Virtual Services - Load Balancers & Pools
+  # ============================================================================
+
+  http_loadbalancer:
+    description: "HTTP/HTTPS load balancer for distributing traffic across origin pools"
+    domain: "virtual"
+    resource_type: "loadbalancer"
+
+    # Minimum required fields for creating a functional HTTP load balancer
+    required_fields:
+      - "metadata.name"
+      - "metadata.namespace"
+      - "spec.domains"  # At least one domain to serve
+      - "spec.routes"   # At least one route to backend
+      - "spec.origin_pools"  # At least one origin pool reference
+
+    # Mutually exclusive field groups - only one from each group allowed
+    mutually_exclusive_groups:
+      - fields: ["spec.dns_name", "spec.advertise"]
+        reason: "Choose either DNS-based or advertised traffic routing"
+      - fields: ["spec.certificate_chain", "spec.tls_config.vault_secret"]
+        reason: "Certificate source: inline or vault"
+
+    # Context-specific field requirements
+    context_requirements:
+      - field: "spec.https"
+        contexts: ["tls", "secure-traffic"]
+        reason: "Required when HTTPS is needed"
+
+      - field: "spec.certificate"
+        depends_on: "spec.https"
+        reason: "Required for TLS termination"
+
+      - field: "spec.rate_limiter"
+        contexts: ["rate-limiting", "protection"]
+        reason: "Recommended for production environments"
+
+    # Example minimal YAML configuration
+    example_yaml: |
+      apiVersion: v1
+      kind: http_loadbalancer
+      metadata:
+        name: example-app
+        namespace: default
+      spec:
+        domains:
+          - example.com
+        https:
+          - port: 443
+            certificate:
+              cert_chain: |
+                -----BEGIN CERTIFICATE-----
+                MIIBkTCB+wIJAKHHCgVPwKWXMA0GCSqGSIb3DQEBBQUAMBExDzANBg...
+                -----END CERTIFICATE-----
+              key: "<example_key_base64_encoded_content_replace_with_actual_key>"
+        http:
+          - port: 80
+            redirect_https: true
+        routes:
+          - prefix: "/"
+            origin_pool:
+              pool_name: backend-pool
+        origin_pools:
+          - name: backend-pool
+            origins:
+              - origin_server:
+                  hostname: backend.example.com
+                  port: 8080
+
+    # Example xcsh CLI command
+    example_command: "xcsh virtual http_loadbalancer create -f http-lb.yaml -n default"
+
+    # CLI metadata
+    cli:
+      domain: "virtual"
+      resource_name: "http_loadbalancer"
+      # Explicit aliases only (no auto-generation)
+      aliases:
+        - "http-lb"
+        - "virtual-service"
+        - "api-endpoint"
+      supported_operations:
+        - create
+        - get
+        - update
+        - delete
+        - list
+
+  # ============================================================================
+
+  origin_pool:
+    description: "Backend origin servers or load balancing pool for distributing traffic"
+    domain: "virtual"
+    resource_type: "pool"
+
+    required_fields:
+      - "metadata.name"
+      - "metadata.namespace"
+      - "spec.origins"  # At least one origin server
+
+    context_requirements:
+      - field: "spec.health_checks"
+        contexts: ["monitoring", "availability"]
+        reason: "Recommended for health monitoring"
+
+    example_yaml: |
+      apiVersion: v1
+      kind: origin_pool
+      metadata:
+        name: backend-pool
+        namespace: default
+      spec:
+        origins:
+          - origin_server:
+              hostname: backend1.example.com
+              port: 8080
+          - origin_server:
+              hostname: backend2.example.com
+              port: 8080
+        health_checks:
+          - health_check_name: http-health-check
+        connection_timeout_ms: 3600
+        idle_timeout_ms: 900000
+
+    example_command: "xcsh virtual origin_pool create -f origin-pool.yaml -n default"
+
+    cli:
+      domain: "virtual"
+      resource_name: "origin_pool"
+      aliases:
+        - "pool"
+        - "backend-pool"
+        - "server-group"
+
+  # ============================================================================
+
+  tcp_loadbalancer:
+    description: "TCP/UDP load balancer for non-HTTP protocols like databases"
+    domain: "virtual"
+    resource_type: "loadbalancer"
+
+    required_fields:
+      - "metadata.name"
+      - "metadata.namespace"
+      - "spec.listener"  # TCP/UDP listener definition
+      - "spec.origin_pools"  # Backend pool reference
+
+    mutually_exclusive_groups:
+      - fields: ["spec.listener.tcp_port", "spec.listener.udp_port"]
+        reason: "Specify either TCP or UDP protocol"
+
+    context_requirements:
+      - field: "spec.listener.tls"
+        contexts: ["tls", "secure"]
+        reason: "Required for encrypted TCP traffic"
+
+    example_yaml: |
+      apiVersion: v1
+      kind: tcp_loadbalancer
+      metadata:
+        name: database-lb
+        namespace: default
+      spec:
+        listener:
+          port: 5432
+          protocol: "TCP"
+        origin_pools:
+          - pool_name: postgres-cluster
+        advertise:
+          - public_ip: true
+
+    example_command: "xcsh virtual tcp_loadbalancer create -f tcp-lb.yaml -n default"
+
+    cli:
+      domain: "virtual"
+      resource_name: "tcp_loadbalancer"
+      aliases:
+        - "tcp-lb"
+        - "database-lb"
+        - "tcp-service"
+
+  # ============================================================================
+
+  healthcheck:
+    description: "Health check configuration for monitoring origin servers"
+    domain: "virtual"
+    resource_type: "monitor"
+
+    required_fields:
+      - "metadata.name"
+      - "metadata.namespace"
+      # One of: spec.http, spec.tcp, spec.dns must be present
+      - "spec"  # Will contain one health check type
+
+    mutually_exclusive_groups:
+      - fields: ["spec.http", "spec.tcp", "spec.dns"]
+        reason: "Choose exactly one health check type"
+
+    example_yaml: |
+      apiVersion: v1
+      kind: healthcheck
+      metadata:
+        name: http-health
+        namespace: default
+      spec:
+        http:
+          path: /health
+          use_origin_server_hostname: true
+        interval_seconds: 10
+        timeout_seconds: 3
+        unhealthy_threshold: 3
+        healthy_threshold: 2
+
+    example_command: "xcsh virtual healthcheck create -f healthcheck.yaml -n default"
+
+    cli:
+      domain: "virtual"
+      resource_name: "healthcheck"
+      aliases:
+        - "health-check"
+        - "monitor"
+        - "probe"
+
+  # ============================================================================
+  # WAF - Web Application Firewall
+  # ============================================================================
+
+  app_firewall:
+    description: "Web Application Firewall (WAF) policy for protecting HTTP applications"
+    domain: "waf"
+    resource_type: "policy"
+
+    required_fields:
+      - "metadata.name"
+      - "metadata.namespace"
+      - "spec.detection_settings"  # Core WAF detection configuration
+
+    context_requirements:
+      - field: "spec.signature_set"
+        contexts: ["signature-protection", "owasp"]
+        reason: "Enables signature-based attack detection"
+
+      - field: "spec.bot_defense"
+        contexts: ["bot-protection"]
+        reason: "Enables bot detection and mitigation"
+
+      - field: "spec.data_guard"
+        contexts: ["sensitive-data"]
+        reason: "Protects sensitive data in responses"
+
+    example_yaml: |
+      apiVersion: v1
+      kind: app_firewall
+      metadata:
+        name: default-waf
+        namespace: default
+      spec:
+        detection_settings:
+          signature_detection: true
+        signature_set:
+          signature_set_name: default_waf_signature_set
+        bot_defense:
+          disabled: false
+        data_guard:
+          disabled: false
+        blocking:
+          disabled: false
+
+    example_command: "xcsh waf app_firewall create -f waf-policy.yaml -n default"
+
+    cli:
+      domain: "waf"
+      resource_name: "app_firewall"
+      aliases:
+        - "firewall"
+        - "waf-policy"
+        - "attack-protection"
+
+# Field-level requirements for cross-resource patterns
+field_requirements:
+  # These patterns apply across all resources
+  - pattern: '\bnamespace$'
+    contexts: ["all"]
+    required: true
+    reason: "F5 XC mandatory namespace for multi-tenancy"
+
+  - pattern: '\bname$'
+    contexts: ["all"]
+    required: true
+    reason: "F5 XC mandatory resource naming"
+
+  - pattern: '\bport$'
+    contexts: ["networking"]
+    required: false
+    reason: "Optional unless protocol specified"
+
+  - pattern: '\bpool'
+    contexts: ["loadbalancing"]
+    required: true
+    reason: "Required for load balancer backend"
+
+# Validation rules
+validation:
+  ensure_config_complete: true
+  ensure_no_duplicates: true
+  ensure_domains_valid: true

--- a/scripts/enrich.py
+++ b/scripts/enrich.py
@@ -31,6 +31,7 @@ from scripts.utils import (
     DiscoveryEnricher,
     FieldMetadataEnricher,
     GrammarImprover,
+    MinimumConfigurationEnricher,
     SchemaFixer,
     TagGenerator,
 )
@@ -259,6 +260,7 @@ def enrich_spec_file(
         description_structure_transformer = DescriptionStructureTransformer()
         schema_fixer = SchemaFixer()
         field_metadata_enricher = FieldMetadataEnricher()
+        minimum_configuration_enricher = MinimumConfigurationEnricher()
         tag_generator = TagGenerator()
         description_validator = DescriptionValidator()
         consistency_validator = ConsistencyValidator()
@@ -290,6 +292,9 @@ def enrich_spec_file(
 
         # 4. Field metadata enrichment (add unified x-ves-* field-level metadata)
         spec = field_metadata_enricher.enrich_spec(spec)
+
+        # 4.5. Minimum configuration enrichment (add x-ves-minimum-configuration)
+        spec = minimum_configuration_enricher.enrich_spec(spec)
 
         # 5. Acronym normalization
         spec = acronym_normalizer.normalize_spec(spec, target_fields)
@@ -343,6 +348,7 @@ def enrich_spec_file(
         tag_stats = tag_generator.get_stats()
         desc_stats = description_validator.get_stats()
         consistency_stats = consistency_validator.get_stats()
+        minimum_config_stats = minimum_configuration_enricher.get_stats()
 
         return EnrichmentResult(
             filename=filename,
@@ -355,6 +361,7 @@ def enrich_spec_file(
                 "tags_generated": tag_stats.get("tags_generated", 0),
                 "descriptions_generated": desc_stats.get("operations_generated", 0),
                 "consistency_issues": consistency_stats.get("total_issues", 0),
+                "minimum_configs_added": minimum_config_stats.get("minimum_configs_added", 0),
                 "discovery_enrichments": discovery_enrichments,
             },
             validation_passed=validation_passed,

--- a/scripts/utils/__init__.py
+++ b/scripts/utils/__init__.py
@@ -13,6 +13,7 @@ from .domain_categorizer import DOMAIN_PATTERNS, DomainCategorizer, categorize_s
 from .field_description_enricher import FieldDescriptionEnricher
 from .field_metadata_enricher import FieldMetadataEnricher
 from .grammar import GrammarImprover
+from .minimum_configuration_enricher import MinimumConfigurationEnricher
 from .operation_metadata_enricher import OperationMetadataEnricher
 from .schema_fixer import SchemaFixer
 from .tag_generator import TagGenerator
@@ -34,6 +35,7 @@ __all__ = [
     "FieldDescriptionEnricher",
     "FieldMetadataEnricher",
     "GrammarImprover",
+    "MinimumConfigurationEnricher",
     "OperationMetadataEnricher",
     "SchemaFixer",
     "TagGenerator",

--- a/scripts/utils/minimum_configuration_enricher.py
+++ b/scripts/utils/minimum_configuration_enricher.py
@@ -1,0 +1,348 @@
+"""Minimum configuration metadata enricher for OpenAPI specifications.
+
+This enricher adds minimum configuration metadata to resource schemas,
+enabling AI assistants and CLI tools to generate working configurations.
+
+Adds four OpenAPI extensions:
+- x-ves-minimum-configuration: Schema-level minimum config definition
+- x-ves-required-for: Field-level context requirements
+- x-ves-cli-domain: Domain classification for CLI routing
+- x-ves-cli-aliases: Alternative names for resources
+"""
+
+import logging
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from .domain_categorizer import DomainCategorizer
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class MinimumConfigurationStats:
+    """Statistics for minimum configuration enrichment."""
+
+    schemas_enriched: int = 0
+    minimum_configs_added: int = 0
+    required_fields_added: int = 0
+    field_requirements_added: int = 0
+    example_yamls_generated: int = 0
+    example_commands_generated: int = 0
+    cli_domains_added: int = 0
+    cli_aliases_added: int = 0
+    errors: list[dict[str, Any]] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert stats to dictionary."""
+        return {
+            "schemas_enriched": self.schemas_enriched,
+            "minimum_configs_added": self.minimum_configs_added,
+            "required_fields_added": self.required_fields_added,
+            "field_requirements_added": self.field_requirements_added,
+            "example_yamls_generated": self.example_yamls_generated,
+            "example_commands_generated": self.example_commands_generated,
+            "cli_domains_added": self.cli_domains_added,
+            "cli_aliases_added": self.cli_aliases_added,
+            "error_count": len(self.errors),
+            "errors": self.errors,
+        }
+
+
+class MinimumConfigurationEnricher:
+    """Enrich OpenAPI specs with minimum configuration metadata.
+
+    Configuration-driven enricher that adds:
+    - Minimum viable configuration examples for each resource
+    - Required fields for functional configurations
+    - CLI metadata for xcsh integration
+    - Domain and resource type classification
+
+    Uses config/minimum_configs.yaml for all definitions.
+    Uses DomainCategorizer singleton for domain auto-mapping.
+    """
+
+    def __init__(self, config_path: Path | None = None) -> None:
+        """Initialize enricher with configuration.
+
+        Args:
+            config_path: Optional path to config file.
+                        Defaults to config/minimum_configs.yaml
+        """
+        self.config_path = (
+            config_path or Path(__file__).parent.parent.parent / "config" / "minimum_configs.yaml"
+        )
+        self.domain_categorizer = DomainCategorizer()
+        self.config: dict[str, Any] = {}
+        self.resources: dict[str, dict[str, Any]] = {}
+        self.stats = MinimumConfigurationStats()
+
+        self._load_config()
+
+    def _load_config(self) -> None:
+        """Load configuration from YAML file."""
+        try:
+            with self.config_path.open() as f:
+                self.config = yaml.safe_load(f) or {}
+                self.resources = self.config.get("resources", {})
+                logger.info("Loaded minimum_configs from %s", self.config_path)
+                logger.info("Found %d resource definitions", len(self.resources))
+        except FileNotFoundError:
+            logger.exception("Configuration file not found: %s", self.config_path)
+            self.config = {}
+            self.resources = {}
+        except yaml.YAMLError:
+            logger.exception("Error parsing configuration")
+            self.config = {}
+            self.resources = {}
+
+    def enrich_spec(self, spec: dict[str, Any]) -> dict[str, Any]:
+        """Enrich OpenAPI specification with minimum configuration metadata.
+
+        Args:
+            spec: OpenAPI specification dictionary
+
+        Returns:
+            Enriched specification
+        """
+        if not self.resources:
+            logger.warning("No resource definitions loaded, skipping enrichment")
+            return spec
+
+        schemas = spec.get("components", {}).get("schemas", {})
+        logger.info("Enriching %d schemas with minimum configuration metadata", len(schemas))
+        for schema_name, schema in schemas.items():
+            self._enrich_schema(schema_name, schema)
+
+        logger.info("Minimum configuration enrichment complete: %s", self.stats.to_dict())
+        return spec
+
+    def _enrich_schema(
+        self,
+        schema_name: str,
+        schema: dict[str, Any],
+    ) -> None:
+        """Enrich individual schema with minimum configuration metadata.
+
+        Args:
+            schema_name: Name of the schema
+            schema: Schema definition
+        """
+        resource_type = self._detect_resource_type(schema_name)
+        if not resource_type or resource_type not in self.resources:
+            return
+
+        resource_config = self.resources[resource_type]
+
+        try:
+            # Add x-ves-minimum-configuration at schema level
+            minimum_config = {
+                "description": resource_config.get("description", ""),
+                "required_fields": self._extract_required_fields(resource_type, schema),
+                "mutually_exclusive_groups": resource_config.get("mutually_exclusive_groups", []),
+                "example_yaml": resource_config.get("example_yaml", ""),
+                "example_command": resource_config.get("example_command", ""),
+            }
+
+            schema["x-ves-minimum-configuration"] = minimum_config
+            self.stats.minimum_configs_added += 1
+
+            # Add x-ves-required-for to schema properties
+            self._add_field_requirements(schema, resource_config)
+
+            # Add x-ves-cli-domain and x-ves-cli-aliases
+            domain = self._get_domain_for_resource(resource_type, schema_name)
+            schema["x-ves-cli-domain"] = domain
+            self.stats.cli_domains_added += 1
+
+            if "cli" in resource_config and "aliases" in resource_config["cli"]:
+                schema["x-ves-cli-aliases"] = resource_config["cli"]["aliases"]
+                self.stats.cli_aliases_added += 1
+
+            self.stats.schemas_enriched += 1
+
+        except Exception as e:
+            logger.exception("Error enriching schema %s", schema_name)
+            self.stats.errors.append(
+                {
+                    "schema": schema_name,
+                    "error": str(e),
+                    "resource_type": resource_type,
+                },
+            )
+
+    def _detect_resource_type(self, schema_name: str) -> str | None:
+        """Detect resource type from schema name.
+
+        Maps schema names to resource types defined in config.
+        Handles variations like CreateSpecType, UpdateSpecType, viewshttp_loadbalancerCreateSpecType.
+
+        Args:
+            schema_name: Name of the schema
+
+        Returns:
+            Resource type if found, None otherwise
+        """
+        # Direct match
+        if schema_name in self.resources:
+            return schema_name
+
+        # Remove common prefixes (e.g., "views", "api", "schema")
+        working_name = schema_name
+        for prefix in ["views", "api", "schema"]:
+            if working_name.startswith(prefix):
+                working_name = working_name[len(prefix) :]
+                break
+
+        # Remove common suffixes in order of specificity
+        for suffix in [
+            "CreateSpecType",
+            "UpdateSpecType",
+            "GetSpecType",
+            "DeleteSpecType",
+            "SpecType",
+            "Spec",
+            "Type",
+            "Request",
+            "Response",
+            "Create",
+            "Update",
+        ]:
+            if working_name.endswith(suffix):
+                base_name = working_name[: -len(suffix)]
+                if base_name in self.resources:
+                    return base_name
+
+        # Try converting case variations (e.g., HttpLoadbalancer -> http_loadbalancer)
+        snake_case = re.sub(r"(?<!^)(?=[A-Z])", "_", working_name).lower()
+        if snake_case in self.resources:
+            return snake_case
+
+        # Try partial matching for compound names
+        for resource in self.resources:
+            if resource in working_name.lower():
+                return resource
+
+        return None
+
+    def _extract_required_fields(self, resource_type: str, schema: dict[str, Any]) -> list[str]:
+        """Extract minimum required fields for resource.
+
+        Uses config-defined required fields if present.
+        Falls back to schema's required array.
+
+        Args:
+            resource_type: Type of resource
+            schema: Schema definition
+
+        Returns:
+            List of required field names
+        """
+        # Use config-defined required fields if present
+        config_required = self.resources.get(resource_type, {}).get("required_fields", [])
+        if config_required:
+            self.stats.required_fields_added += 1
+            return config_required
+
+        # Fallback to schema required array
+        return schema.get("required", [])
+
+    def _add_field_requirements(
+        self,
+        schema: dict[str, Any],
+        resource_config: dict[str, Any],
+    ) -> None:
+        """Add x-ves-required-for to schema properties.
+
+        Args:
+            schema: Schema definition
+            resource_config: Resource configuration from config file
+        """
+        properties = schema.get("properties", {})
+        if not properties:
+            return
+
+        required_fields = self._extract_required_fields_list(resource_config)
+
+        for field_name, field_schema in properties.items():
+            if not isinstance(field_schema, dict):
+                continue
+            is_required = field_name in required_fields
+            field_requirements = {
+                "minimum_config": is_required,
+                "create": is_required,
+                "update": False,
+                "read": False,
+            }
+            field_schema["x-ves-required-for"] = field_requirements
+            self.stats.field_requirements_added += 1
+
+    def _extract_required_fields_list(self, resource_config: dict[str, Any]) -> list[str]:
+        """Extract required fields list from resource config.
+
+        Args:
+            resource_config: Resource configuration
+
+        Returns:
+            List of required field names
+        """
+        required = resource_config.get("required_fields", [])
+        # Convert nested paths (e.g., "metadata.name") to top-level field names for property matching
+        field_names = []
+        for field_path in required:
+            # Get the top-level field name
+            top_level = field_path.split(".")[0]
+            if top_level not in field_names:
+                field_names.append(top_level)
+        return field_names
+
+    def _get_domain_for_resource(self, resource_type: str, schema_name: str) -> str:
+        """Get domain classification for resource.
+
+        Priority:
+        1. Explicit domain in config
+        2. DomainCategorizer mapping
+        3. Resource name inference
+        4. Fallback
+
+        Args:
+            resource_type: Type of resource
+            schema_name: Schema name for categorizer
+
+        Returns:
+            Domain classification
+        """
+        # Check config
+        config_domain = self.resources.get(resource_type, {}).get("domain")
+        if config_domain:
+            return config_domain
+
+        # Try DomainCategorizer
+        try:
+            domain = self.domain_categorizer.categorize(schema_name)
+            if domain:
+                return domain
+        except Exception as e:
+            logger.debug("DomainCategorizer failed for %s: %s", schema_name, e)
+
+        # Fallback: infer from resource type
+        if "virtual" in resource_type.lower() or "loadbalancer" in resource_type.lower():
+            return "virtual"
+        if "waf" in resource_type.lower() or "firewall" in resource_type.lower():
+            return "waf"
+        if "pool" in resource_type.lower():
+            return "virtual"
+
+        return "other"
+
+    def get_stats(self) -> dict[str, Any]:
+        """Get enrichment statistics.
+
+        Returns:
+            Statistics dictionary
+        """
+        return self.stats.to_dict()

--- a/tests/test_minimum_configuration_enricher.py
+++ b/tests/test_minimum_configuration_enricher.py
@@ -1,0 +1,393 @@
+"""Tests for MinimumConfigurationEnricher.
+
+Tests the enrichment of OpenAPI specs with minimum configuration metadata
+for AI-assisted resource creation.
+"""
+
+import pytest
+
+from scripts.utils.minimum_configuration_enricher import (
+    MinimumConfigurationEnricher,
+    MinimumConfigurationStats,
+)
+
+
+class TestMinimumConfigurationStats:
+    """Test MinimumConfigurationStats dataclass."""
+
+    def test_stats_initialization(self):
+        """Test stats initialization with default values."""
+        stats = MinimumConfigurationStats()
+        assert stats.schemas_enriched == 0
+        assert stats.minimum_configs_added == 0
+        assert stats.required_fields_added == 0
+        assert stats.field_requirements_added == 0
+        assert stats.example_yamls_generated == 0
+        assert stats.example_commands_generated == 0
+        assert stats.cli_domains_added == 0
+        assert stats.cli_aliases_added == 0
+        assert stats.errors == []
+
+    def test_stats_to_dict(self):
+        """Test stats conversion to dictionary."""
+        stats = MinimumConfigurationStats()
+        stats.schemas_enriched = 5
+        stats.minimum_configs_added = 5
+        stats.required_fields_added = 10
+
+        result = stats.to_dict()
+        assert result["schemas_enriched"] == 5
+        assert result["minimum_configs_added"] == 5
+        assert result["required_fields_added"] == 10
+        assert "error_count" in result
+
+
+class TestMinimumConfigurationEnricherBasics:
+    """Test basic MinimumConfigurationEnricher functionality."""
+
+    def test_enricher_initialization(self):
+        """Test enricher initializes with config loaded."""
+        enricher = MinimumConfigurationEnricher()
+        assert enricher.config is not None
+        assert enricher.resources is not None
+        assert len(enricher.resources) > 0
+        assert enricher.stats is not None
+
+    def test_resources_loaded(self):
+        """Test that all 5 priority resources are loaded."""
+        enricher = MinimumConfigurationEnricher()
+        expected_resources = {
+            "http_loadbalancer",
+            "origin_pool",
+            "tcp_loadbalancer",
+            "healthcheck",
+            "app_firewall",
+        }
+        loaded_resources = set(enricher.resources.keys())
+        for resource in expected_resources:
+            assert resource in loaded_resources, f"Missing resource: {resource}"
+
+    def test_domain_categorizer_initialized(self):
+        """Test that DomainCategorizer singleton is initialized."""
+        enricher = MinimumConfigurationEnricher()
+        assert enricher.domain_categorizer is not None
+        # Verify it can categorize schemas
+        domain = enricher.domain_categorizer.categorize("http_loadbalancer")
+        assert domain is not None
+
+
+class TestResourceDetection:
+    """Test resource type detection from schema names."""
+
+    def test_detect_direct_match(self):
+        """Test direct schema name match."""
+        enricher = MinimumConfigurationEnricher()
+        assert enricher._detect_resource_type("http_loadbalancer") == "http_loadbalancer"  # noqa: SLF001
+        assert enricher._detect_resource_type("origin_pool") == "origin_pool"  # noqa: SLF001
+
+    def test_detect_with_request_suffix(self):
+        """Test detection with Request suffix."""
+        enricher = MinimumConfigurationEnricher()
+        assert (
+            enricher._detect_resource_type("http_loadbalancerCreateRequest") == "http_loadbalancer"  # noqa: SLF001
+        )
+        assert enricher._detect_resource_type("origin_poolCreateRequest") == "origin_pool"  # noqa: SLF001
+
+    def test_detect_with_spec_type_suffix(self):
+        """Test detection with SpecType suffix."""
+        enricher = MinimumConfigurationEnricher()
+        assert (
+            enricher._detect_resource_type("http_loadbalancerCreateSpecType") == "http_loadbalancer"  # noqa: SLF001
+        )
+        assert enricher._detect_resource_type("healthcheckCreateSpecType") == "healthcheck"  # noqa: SLF001
+
+    def test_detect_with_response_suffix(self):
+        """Test detection with Response suffix."""
+        enricher = MinimumConfigurationEnricher()
+        assert enricher._detect_resource_type("origin_poolCreateResponse") == "origin_pool"  # noqa: SLF001
+        assert enricher._detect_resource_type("tcp_loadbalancerGetResponse") == "tcp_loadbalancer"  # noqa: SLF001
+
+    def test_detect_partial_matching(self):
+        """Test partial matching for compound names."""
+        enricher = MinimumConfigurationEnricher()
+        # Should find 'app_firewall' in longer name
+        result = enricher._detect_resource_type("app_firewallSomeOtherType")  # noqa: SLF001
+        assert result == "app_firewall"
+
+    def test_detect_no_match(self):
+        """Test detection with non-matching schema."""
+        enricher = MinimumConfigurationEnricher()
+        result = enricher._detect_resource_type("SomeRandomSchema")  # noqa: SLF001
+        assert result is None
+
+    def test_detect_http_loadbalancer_variants(self):
+        """Test detection of various http_loadbalancer schema name variations."""
+        enricher = MinimumConfigurationEnricher()
+        variants = [
+            "http_loadbalancerCreateRequest",
+            "http_loadbalancerUpdateRequest",
+            "http_loadbalancerGetResponse",
+            "http_loadbalancerDeleteResponse",
+            "http_loadbalancerCreateSpecType",
+            "http_loadbalancerUpdateSpecType",
+            "http_loadbalancerGetSpecType",
+        ]
+        for variant in variants:
+            result = enricher._detect_resource_type(variant)  # noqa: SLF001
+            assert result == "http_loadbalancer", f"Failed to detect {variant}"
+
+
+class TestRequiredFieldExtraction:
+    """Test extraction of required fields from schema."""
+
+    def test_extract_config_required_fields(self):
+        """Test extraction of required fields from config."""
+        enricher = MinimumConfigurationEnricher()
+        resource_type = "http_loadbalancer"
+        schema = {}
+
+        required = enricher._extract_required_fields(resource_type, schema)  # noqa: SLF001
+        assert isinstance(required, list)
+        assert len(required) > 0
+        # Should include metadata.name and metadata.namespace
+        assert any("metadata.name" in field for field in required)
+
+    def test_extract_required_fields_from_nested_config(self):
+        """Test extraction handles nested field paths."""
+        enricher = MinimumConfigurationEnricher()
+        required_fields = enricher.resources.get("origin_pool", {}).get("required_fields", [])
+        assert required_fields is not None
+        assert len(required_fields) > 0
+
+
+class TestExampleGeneration:
+    """Test example YAML and CLI command generation."""
+
+    def test_example_yaml_generation(self):
+        """Test that example YAML is configured for resources."""
+        enricher = MinimumConfigurationEnricher()
+        for resource in [
+            "http_loadbalancer",
+            "origin_pool",
+            "tcp_loadbalancer",
+            "healthcheck",
+            "app_firewall",
+        ]:
+            resource_config = enricher.resources.get(resource, {})
+            example_yaml = resource_config.get("example_yaml", "")
+            assert example_yaml, f"No example_yaml for {resource}"
+            assert "apiVersion" in example_yaml or "kind" in example_yaml, (
+                f"Invalid YAML structure for {resource}"
+            )
+
+    def test_example_command_generation(self):
+        """Test that example CLI commands are configured for resources."""
+        enricher = MinimumConfigurationEnricher()
+        for resource in [
+            "http_loadbalancer",
+            "origin_pool",
+            "tcp_loadbalancer",
+            "healthcheck",
+            "app_firewall",
+        ]:
+            resource_config = enricher.resources.get(resource, {})
+            example_command = resource_config.get("example_command", "")
+            assert example_command, f"No example_command for {resource}"
+            assert "xcsh" in example_command, f"Invalid xcsh command for {resource}"
+
+    def test_cli_aliases_configured(self):
+        """Test that CLI aliases are explicitly configured."""
+        enricher = MinimumConfigurationEnricher()
+        for resource in [
+            "http_loadbalancer",
+            "origin_pool",
+            "tcp_loadbalancer",
+            "healthcheck",
+            "app_firewall",
+        ]:
+            resource_config = enricher.resources.get(resource, {})
+            cli_config = resource_config.get("cli", {})
+            aliases = cli_config.get("aliases", [])
+            assert isinstance(aliases, list), f"CLI aliases not configured for {resource}"
+
+
+class TestDomainMapping:
+    """Test domain classification for resources."""
+
+    def test_get_domain_for_http_loadbalancer(self):
+        """Test domain mapping for http_loadbalancer."""
+        enricher = MinimumConfigurationEnricher()
+        domain = enricher._get_domain_for_resource(  # noqa: SLF001
+            "http_loadbalancer",
+            "http_loadbalancerCreateRequest",
+        )
+        assert domain is not None
+        assert domain in ["virtual", "cdn", "loadbalancing"]
+
+    def test_get_domain_for_app_firewall(self):
+        """Test domain mapping for app_firewall."""
+        enricher = MinimumConfigurationEnricher()
+        domain = enricher._get_domain_for_resource("app_firewall", "app_firewallCreateRequest")  # noqa: SLF001
+        assert domain == "waf"
+
+    def test_get_domain_explicit_config(self):
+        """Test that explicit domain in config is used."""
+        enricher = MinimumConfigurationEnricher()
+        # http_loadbalancer should have explicit domain configured
+        domain = enricher._get_domain_for_resource(  # noqa: SLF001
+            "http_loadbalancer",
+            "http_loadbalancerCreateRequest",
+        )
+        assert domain is not None
+
+
+class TestFullEnrichment:
+    """Test full enrichment workflow."""
+
+    def test_enrich_spec_with_resources(self):
+        """Test enriching spec with resource schemas."""
+        enricher = MinimumConfigurationEnricher()
+
+        # Create minimal spec with http_loadbalancer schema
+        spec = {
+            "components": {
+                "schemas": {
+                    "http_loadbalancerCreateRequest": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"},
+                            "namespace": {"type": "string"},
+                        },
+                    },
+                },
+            },
+        }
+
+        enriched = enricher.enrich_spec(spec)
+
+        # Verify schema was enriched with minimum configuration
+        schema = enriched["components"]["schemas"]["http_loadbalancerCreateRequest"]
+        assert "x-ves-minimum-configuration" in schema
+        assert "x-ves-cli-domain" in schema
+        assert enricher.stats.minimum_configs_added > 0
+
+    def test_enrich_preserves_original_schema(self):
+        """Test that enrichment preserves original schema properties."""
+        enricher = MinimumConfigurationEnricher()
+
+        original_type = "object"
+        original_properties = {"name": {"type": "string"}}
+
+        spec = {
+            "components": {
+                "schemas": {
+                    "http_loadbalancerCreateRequest": {
+                        "type": original_type,
+                        "properties": original_properties,
+                    },
+                },
+            },
+        }
+
+        enriched = enricher.enrich_spec(spec)
+        schema = enriched["components"]["schemas"]["http_loadbalancerCreateRequest"]
+
+        # Verify original properties are preserved
+        assert schema["type"] == original_type
+        assert schema["properties"] == original_properties
+
+    def test_enrich_empty_spec(self):
+        """Test enriching spec with no schemas."""
+        enricher = MinimumConfigurationEnricher()
+        spec = {"components": {"schemas": {}}}
+        enricher.enrich_spec(spec)
+        assert enricher.stats.minimum_configs_added == 0
+
+    def test_enrich_no_matching_resources(self):
+        """Test enriching spec with no matching resources."""
+        enricher = MinimumConfigurationEnricher()
+        spec = {
+            "components": {
+                "schemas": {
+                    "UnrelatedSchema": {"type": "object"},
+                },
+            },
+        }
+        enricher.enrich_spec(spec)
+        assert enricher.stats.minimum_configs_added == 0
+
+    def test_stats_collection(self):
+        """Test that statistics are properly collected during enrichment."""
+        enricher = MinimumConfigurationEnricher()
+
+        spec = {
+            "components": {
+                "schemas": {
+                    "http_loadbalancerCreateRequest": {
+                        "type": "object",
+                        "properties": {"name": {"type": "string"}},
+                    },
+                    "origin_poolCreateRequest": {
+                        "type": "object",
+                        "properties": {"name": {"type": "string"}},
+                    },
+                },
+            },
+        }
+
+        enricher.enrich_spec(spec)
+        stats = enricher.get_stats()
+
+        assert stats["schemas_enriched"] >= 2
+        assert stats["minimum_configs_added"] >= 2
+        assert stats["cli_domains_added"] >= 2
+        assert len(stats["errors"]) == 0
+
+
+class TestAllFiveResources:
+    """Test enrichment for all 5 priority resources."""
+
+    @pytest.mark.parametrize(
+        ("resource_type", "schema_name"),
+        [
+            ("http_loadbalancer", "http_loadbalancerCreateRequest"),
+            ("origin_pool", "origin_poolCreateRequest"),
+            ("tcp_loadbalancer", "tcp_loadbalancerCreateRequest"),
+            ("healthcheck", "healthcheckCreateRequest"),
+            ("app_firewall", "app_firewallCreateRequest"),
+        ],
+    )
+    def test_enrich_all_resources(self, resource_type, schema_name):
+        """Test enrichment for all 5 resources."""
+        enricher = MinimumConfigurationEnricher()
+
+        spec = {
+            "components": {
+                "schemas": {
+                    schema_name: {
+                        "type": "object",
+                        "properties": {"name": {"type": "string"}},
+                    },
+                },
+            },
+        }
+
+        enriched = enricher.enrich_spec(spec)
+        schema = enriched["components"]["schemas"][schema_name]
+
+        # Verify minimum configuration was added
+        assert "x-ves-minimum-configuration" in schema, f"No minimum config for {resource_type}"
+
+        min_config = schema["x-ves-minimum-configuration"]
+        assert "required_fields" in min_config
+        assert "description" in min_config
+        assert "example_yaml" in min_config
+        assert "example_command" in min_config
+
+        # Verify CLI metadata was added
+        assert "x-ves-cli-domain" in schema
+        assert schema["x-ves-cli-domain"] is not None
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Implements GitHub Issue #152: Adds minimum configuration metadata to OpenAPI specs to enable AI assistants and CLI tools to generate deterministic, working configurations.

**Key Features:**
- ✅ 5 priority resources enriched (http_loadbalancer, origin_pool, tcp_loadbalancer, healthcheck, app_firewall)
- ✅ 219 minimum configuration metadata objects added
- ✅ 4 new OpenAPI extensions (x-ves-minimum-configuration, x-ves-required-for, x-ves-cli-domain, x-ves-cli-aliases)
- ✅ YAML examples and xcsh CLI commands for all resources
- ✅ Auto domain mapping using existing DomainCategorizer

## Test Plan

- [x] All 30 comprehensive tests passing
- [x] Full pipeline runs successfully (219 configs, 0 errors)
- [x] All 40 specifications pass linting (0 errors, 0 warnings)
- [x] Pre-commit hooks all passing

🤖 Generated with Claude Code

Closes #153