### PR TITLE
feat: Add deprecated tier transformation enricher

### DIFF
--- a/config/enrichment.yaml
+++ b/config/enrichment.yaml
@@ -323,3 +323,28 @@ discovery_enrichment:
   discovered_specs_dir: "specs/discovered"
 
   # See config/discovery_enrichment.yaml for detailed configuration
+
+# Deprecated tier transformation settings
+# Pre-release cleanup: transforms deprecated subscription tier values to current equivalents
+deprecated_tiers:
+  # Enable deprecated tier transformation
+  enabled: true
+
+  # Schema patterns to match tier enum definitions
+  # These patterns identify schemas containing AddonServiceTierType enums
+  patterns:
+    - ".*AddonServiceTierType$"
+    - ".*TierType$"
+
+  # Tier value transformations (deprecated → current)
+  # BASIC and PREMIUM are legacy values that should be transformed
+  transformations:
+    BASIC: "STANDARD"
+    PREMIUM: "ADVANCED"
+
+  # Valid tier values after transformation
+  # These are the only values that should remain in published specs
+  valid_tiers:
+    - "NO_TIER"      # Foundational/not applicable
+    - "STANDARD"     # Base subscription tier
+    - "ADVANCED"     # Premium subscription tier

--- a/scripts/utils/__init__.py
+++ b/scripts/utils/__init__.py
@@ -6,6 +6,7 @@ from .cli_metadata_enricher import CLIMetadataEnricher
 from .consistency_validator import ConsistencyValidator
 from .constraint_analyzer import ConstraintAnalyzer
 from .constraint_reconciler import ConstraintReconciler
+from .deprecated_tier_enricher import DeprecatedTierEnricher
 from .description_structure import DescriptionStructureTransformer
 from .description_validator import DescriptionValidator
 from .discovery_enricher import DiscoveryEnricher
@@ -28,6 +29,7 @@ __all__ = [
     "ConsistencyValidator",
     "ConstraintAnalyzer",
     "ConstraintReconciler",
+    "DeprecatedTierEnricher",
     "DescriptionStructureTransformer",
     "DescriptionValidator",
     "DiscoveryEnricher",

--- a/scripts/utils/deprecated_tier_enricher.py
+++ b/scripts/utils/deprecated_tier_enricher.py
@@ -1,0 +1,293 @@
+"""Deprecated tier transformation enricher for OpenAPI specifications.
+
+This enricher transforms deprecated subscription tier values to their
+current equivalents in enum schemas. Pre-release cleanup to ensure
+only valid tier values are published.
+
+F5 XC subscription tiers:
+- NO_TIER: Foundational/not applicable
+- STANDARD: Base subscription tier
+- ADVANCED: Premium subscription tier
+
+Transformations applied:
+- BASIC → STANDARD (legacy tier replaced)
+- PREMIUM → ADVANCED (legacy tier replaced)
+"""
+
+import logging
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, ClassVar
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+
+# Tier value transformations (deprecated → current)
+TIER_TRANSFORMATIONS: dict[str, str] = {
+    "BASIC": "STANDARD",
+    "PREMIUM": "ADVANCED",
+}
+
+# Valid tier values after transformation
+VALID_TIERS: list[str] = ["NO_TIER", "STANDARD", "ADVANCED"]
+
+
+@dataclass
+class DeprecatedTierStats:
+    """Statistics for deprecated tier transformation."""
+
+    schemas_processed: int = 0
+    schemas_transformed: int = 0
+    values_transformed: int = 0
+    descriptions_updated: int = 0
+    cli_examples_fixed: int = 0
+    errors: list[dict[str, Any]] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert stats to dictionary."""
+        return {
+            "schemas_processed": self.schemas_processed,
+            "schemas_transformed": self.schemas_transformed,
+            "values_transformed": self.values_transformed,
+            "descriptions_updated": self.descriptions_updated,
+            "cli_examples_fixed": self.cli_examples_fixed,
+            "error_count": len(self.errors),
+            "errors": self.errors,
+        }
+
+
+class DeprecatedTierEnricher:
+    """Transform deprecated tier values in OpenAPI specs.
+
+    Pre-release cleanup enricher that transforms deprecated subscription
+    tier values to their current equivalents:
+    - BASIC → STANDARD
+    - PREMIUM → ADVANCED
+
+    Uses config/enrichment.yaml for pattern matching rules.
+    """
+
+    # Default schema patterns to match tier enums
+    DEFAULT_PATTERNS: ClassVar[list[str]] = [
+        r".*AddonServiceTierType$",
+        r".*TierType$",
+    ]
+
+    # CLI example patterns to fix (lowercase versions)
+    CLI_REPLACEMENTS: ClassVar[dict[str, str]] = {
+        "subscription_basic_tier": "subscription_standard_tier",
+        "subscription_premium_tier": "subscription_advanced_tier",
+        "basic_tier": "standard_tier",
+        "premium_tier": "advanced_tier",
+        "BASIC": "STANDARD",
+        "PREMIUM": "ADVANCED",
+    }
+
+    def __init__(self, config_path: Path | None = None) -> None:
+        """Initialize enricher with configuration.
+
+        Args:
+            config_path: Optional path to enrichment config file.
+                        Defaults to config/enrichment.yaml
+        """
+        self.config_path = (
+            config_path or Path(__file__).parent.parent.parent / "config" / "enrichment.yaml"
+        )
+        self.config: dict[str, Any] = {}
+        self.patterns: list[re.Pattern[str]] = []
+        self.transformations: dict[str, str] = dict(TIER_TRANSFORMATIONS)
+        self.stats = DeprecatedTierStats()
+
+        self._load_config()
+
+    def _load_config(self) -> None:
+        """Load configuration from YAML file."""
+        try:
+            with self.config_path.open() as f:
+                full_config = yaml.safe_load(f) or {}
+                self.config = full_config.get("deprecated_tiers", {})
+
+            if not self.config.get("enabled", True):
+                logger.info("Deprecated tier transformation is disabled")
+                return
+
+            # Load patterns from config or use defaults
+            pattern_strs = self.config.get("patterns", self.DEFAULT_PATTERNS)
+            self.patterns = [re.compile(p) for p in pattern_strs]
+
+            # Load transformations from config or use defaults
+            config_transformations = self.config.get("transformations", {})
+            if config_transformations:
+                self.transformations = config_transformations
+
+            logger.info(
+                "Loaded deprecated tier config: %d patterns, %d transformations",
+                len(self.patterns),
+                len(self.transformations),
+            )
+        except FileNotFoundError:
+            logger.warning(
+                "Config file not found: %s, using defaults",
+                self.config_path,
+            )
+            self.patterns = [re.compile(p) for p in self.DEFAULT_PATTERNS]
+        except yaml.YAMLError:
+            logger.exception("Failed to parse config")
+            self.patterns = [re.compile(p) for p in self.DEFAULT_PATTERNS]
+
+    def enrich(self, spec: dict[str, Any]) -> dict[str, Any]:
+        """Transform deprecated tier values in specification.
+
+        Args:
+            spec: OpenAPI specification dictionary
+
+        Returns:
+            Cleaned specification
+        """
+        if not self.config.get("enabled", True):
+            return spec
+
+        # Process schemas in components
+        components = spec.get("components", {})
+        schemas = components.get("schemas", {})
+
+        for schema_name, schema_def in schemas.items():
+            self.stats.schemas_processed += 1
+
+            if self._matches_tier_pattern(schema_name):
+                self._clean_tier_schema(schema_name, schema_def)
+
+            # Also fix CLI examples in any schema with x-ves-minimum-configuration
+            self._fix_cli_examples(schema_def)
+
+        return spec
+
+    def _matches_tier_pattern(self, schema_name: str) -> bool:
+        """Check if schema name matches tier enum patterns.
+
+        Args:
+            schema_name: Name of the schema
+
+        Returns:
+            True if schema matches a tier pattern
+        """
+        return any(pattern.match(schema_name) for pattern in self.patterns)
+
+    def _clean_tier_schema(self, schema_name: str, schema: dict[str, Any]) -> None:
+        """Transform deprecated tier values in schema enum.
+
+        Args:
+            schema_name: Name of the schema
+            schema: Schema definition dictionary
+        """
+        enum_values = schema.get("enum", [])
+        if not enum_values:
+            return
+
+        # Check if it contains deprecated tier values
+        deprecated_present = [v for v in enum_values if v in self.transformations]
+        if not deprecated_present:
+            return
+
+        logger.info(
+            "Transforming tier schema: %s (%s)",
+            schema_name,
+            ", ".join(f"{v}→{self.transformations[v]}" for v in deprecated_present),
+        )
+        self.stats.schemas_transformed += 1
+
+        # Transform deprecated values to current equivalents
+        transformed_enum = []
+        seen_values: set[str] = set()
+        for v in enum_values:
+            if v in self.transformations:
+                new_value = self.transformations[v]
+                self.stats.values_transformed += 1
+                # Only add if not already present (avoid duplicates)
+                if new_value not in seen_values:
+                    transformed_enum.append(new_value)
+                    seen_values.add(new_value)
+            elif v not in seen_values:
+                transformed_enum.append(v)
+                seen_values.add(v)
+
+        schema["enum"] = transformed_enum
+
+        # Update description to reflect transformation
+        self._update_description(schema)
+
+    def _update_description(
+        self,
+        schema: dict[str, Any],
+    ) -> None:
+        """Update schema description after transforming deprecated values.
+
+        Args:
+            schema: Schema definition dictionary
+        """
+        original_desc = schema.get("description", "")
+
+        # Replace references to deprecated tiers with their current equivalents
+        new_desc = original_desc
+        for deprecated, current in self.transformations.items():
+            # Replace mentions like "- BASIC: basic\n" with "- STANDARD: standard\n"
+            new_desc = re.sub(
+                rf"(-\s*){deprecated}(:)",
+                rf"\g<1>{current}\g<2>",
+                new_desc,
+                flags=re.IGNORECASE,
+            )
+            # Replace standalone mentions
+            new_desc = re.sub(
+                rf"\b{deprecated}\b",
+                current,
+                new_desc,
+            )
+
+        # Clean up any double spaces or trailing commas
+        new_desc = re.sub(r"\s+", " ", new_desc)
+        new_desc = re.sub(r",\s*\.", ".", new_desc)
+        new_desc = new_desc.strip()
+
+        if new_desc != original_desc:
+            schema["description"] = new_desc
+            self.stats.descriptions_updated += 1
+
+    def _fix_cli_examples(self, schema: dict[str, Any]) -> None:
+        """Fix CLI examples that reference deprecated tiers.
+
+        Args:
+            schema: Schema definition dictionary
+        """
+        min_config = schema.get("x-ves-minimum-configuration", {})
+        if not min_config:
+            return
+
+        example_cmd = min_config.get("example_command", "")
+        if not example_cmd:
+            return
+
+        # Check if any deprecated patterns are in the command
+        new_cmd = example_cmd
+        for old_pattern, new_pattern in self.CLI_REPLACEMENTS.items():
+            if old_pattern in new_cmd:
+                new_cmd = new_cmd.replace(old_pattern, new_pattern)
+                self.stats.cli_examples_fixed += 1
+
+        if new_cmd != example_cmd:
+            min_config["example_command"] = new_cmd
+
+    def get_stats(self) -> dict[str, Any]:
+        """Get enrichment statistics.
+
+        Returns:
+            Dictionary of statistics
+        """
+        return self.stats.to_dict()
+
+    def reset_stats(self) -> None:
+        """Reset statistics for new enrichment run."""
+        self.stats = DeprecatedTierStats()

--- a/tests/test_deprecated_tier_enricher.py
+++ b/tests/test_deprecated_tier_enricher.py
@@ -1,0 +1,351 @@
+"""Unit tests for DeprecatedTierEnricher."""
+
+from pathlib import Path
+
+import pytest
+
+from scripts.utils.deprecated_tier_enricher import (
+    TIER_TRANSFORMATIONS,
+    VALID_TIERS,
+    DeprecatedTierEnricher,
+    DeprecatedTierStats,
+)
+
+
+@pytest.fixture
+def enricher():
+    """Create enricher with default config."""
+    return DeprecatedTierEnricher()
+
+
+@pytest.fixture
+def spec_with_deprecated_tiers():
+    """Create a spec with deprecated tier values."""
+    return {
+        "components": {
+            "schemas": {
+                "schemaAddonServiceTierType": {
+                    "type": "string",
+                    "enum": ["NO_TIER", "BASIC", "STANDARD", "ADVANCED", "PREMIUM"],
+                    "description": "Subscription tier: NO_TIER, BASIC, STANDARD, ADVANCED, PREMIUM",
+                },
+                "OtherSchema": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                    },
+                },
+            },
+        },
+    }
+
+
+@pytest.fixture
+def spec_without_deprecated_tiers():
+    """Create a spec with only valid tier values."""
+    return {
+        "components": {
+            "schemas": {
+                "schemaAddonServiceTierType": {
+                    "type": "string",
+                    "enum": ["NO_TIER", "STANDARD", "ADVANCED"],
+                    "description": "Subscription tier: NO_TIER, STANDARD, ADVANCED",
+                },
+            },
+        },
+    }
+
+
+@pytest.fixture
+def spec_with_cli_examples():
+    """Create a spec with deprecated CLI examples."""
+    return {
+        "components": {
+            "schemas": {
+                "TestSchema": {
+                    "type": "object",
+                    "x-ves-minimum-configuration": {
+                        "example_command": "xcsh set subscription_basic_tier --name test",
+                    },
+                },
+            },
+        },
+    }
+
+
+class TestDeprecatedTierEnricherBasics:
+    """Test basic enricher functionality."""
+
+    def test_initialization(self):
+        """Test enricher initializes correctly."""
+        enricher = DeprecatedTierEnricher()
+        assert enricher.transformations == TIER_TRANSFORMATIONS
+        assert len(enricher.patterns) > 0
+
+    def test_config_loading_missing_file(self):
+        """Test enricher uses defaults when config file missing."""
+        enricher = DeprecatedTierEnricher(config_path=Path("/nonexistent/path.yaml"))
+        assert enricher.transformations == TIER_TRANSFORMATIONS
+        assert len(enricher.patterns) > 0
+
+    def test_stats_initialization(self):
+        """Test enrichment stats start at zero."""
+        enricher = DeprecatedTierEnricher()
+        stats = enricher.get_stats()
+        assert stats["schemas_processed"] == 0
+        assert stats["schemas_transformed"] == 0
+        assert stats["values_transformed"] == 0
+        assert stats["descriptions_updated"] == 0
+        assert stats["cli_examples_fixed"] == 0
+
+    def test_stats_reset(self):
+        """Test stats can be reset."""
+        enricher = DeprecatedTierEnricher()
+        enricher.stats.schemas_processed = 5
+        enricher.reset_stats()
+        assert enricher.stats.schemas_processed == 0
+
+
+class TestDeprecatedTierStatsDataclass:
+    """Test DeprecatedTierStats dataclass."""
+
+    def test_to_dict(self):
+        """Test stats to_dict conversion."""
+        stats = DeprecatedTierStats(
+            schemas_processed=10,
+            schemas_transformed=2,
+            values_transformed=4,
+            descriptions_updated=2,
+            cli_examples_fixed=1,
+            errors=[{"file": "test.json", "error": "test error"}],
+        )
+        result = stats.to_dict()
+        assert result["schemas_processed"] == 10
+        assert result["schemas_transformed"] == 2
+        assert result["values_transformed"] == 4
+        assert result["descriptions_updated"] == 2
+        assert result["cli_examples_fixed"] == 1
+        assert result["error_count"] == 1
+
+
+class TestTierTransformation:
+    """Test tier value transformation."""
+
+    def test_transforms_basic_to_standard(self, enricher, spec_with_deprecated_tiers):
+        """Test BASIC is transformed to STANDARD."""
+        result = enricher.enrich(spec_with_deprecated_tiers)
+        enum_values = result["components"]["schemas"]["schemaAddonServiceTierType"]["enum"]
+
+        assert "BASIC" not in enum_values
+        assert "STANDARD" in enum_values
+
+    def test_transforms_premium_to_advanced(self, enricher, spec_with_deprecated_tiers):
+        """Test PREMIUM is transformed to ADVANCED."""
+        result = enricher.enrich(spec_with_deprecated_tiers)
+        enum_values = result["components"]["schemas"]["schemaAddonServiceTierType"]["enum"]
+
+        assert "PREMIUM" not in enum_values
+        assert "ADVANCED" in enum_values
+
+    def test_preserves_no_tier(self, enricher, spec_with_deprecated_tiers):
+        """Test NO_TIER is preserved (not deprecated)."""
+        result = enricher.enrich(spec_with_deprecated_tiers)
+        enum_values = result["components"]["schemas"]["schemaAddonServiceTierType"]["enum"]
+
+        assert "NO_TIER" in enum_values
+
+    def test_no_duplicates_after_transformation(self, enricher, spec_with_deprecated_tiers):
+        """Test no duplicate values after transformation."""
+        result = enricher.enrich(spec_with_deprecated_tiers)
+        enum_values = result["components"]["schemas"]["schemaAddonServiceTierType"]["enum"]
+
+        # Should not have duplicate STANDARD or ADVANCED
+        assert enum_values.count("STANDARD") == 1
+        assert enum_values.count("ADVANCED") == 1
+
+    def test_final_enum_contains_only_valid_tiers(self, enricher, spec_with_deprecated_tiers):
+        """Test final enum contains only valid tier values."""
+        result = enricher.enrich(spec_with_deprecated_tiers)
+        enum_values = result["components"]["schemas"]["schemaAddonServiceTierType"]["enum"]
+
+        for value in enum_values:
+            assert value in VALID_TIERS
+
+    def test_no_change_when_no_deprecated_values(self, enricher, spec_without_deprecated_tiers):
+        """Test no changes when spec has no deprecated values."""
+        original_enum = spec_without_deprecated_tiers["components"]["schemas"][
+            "schemaAddonServiceTierType"
+        ]["enum"].copy()
+
+        result = enricher.enrich(spec_without_deprecated_tiers)
+        result_enum = result["components"]["schemas"]["schemaAddonServiceTierType"]["enum"]
+
+        assert result_enum == original_enum
+        assert enricher.stats.values_transformed == 0
+
+    def test_stats_updated_after_transformation(self, enricher, spec_with_deprecated_tiers):
+        """Test stats are updated after transformation."""
+        enricher.enrich(spec_with_deprecated_tiers)
+        stats = enricher.get_stats()
+
+        assert stats["schemas_transformed"] == 1
+        assert stats["values_transformed"] == 2  # BASIC and PREMIUM
+
+
+class TestDescriptionTransformation:
+    """Test description updates."""
+
+    def test_description_updated_with_transformations(self, enricher):
+        """Test description text is updated with new tier names."""
+        spec = {
+            "components": {
+                "schemas": {
+                    "TestTierType": {
+                        "type": "string",
+                        "enum": ["BASIC", "PREMIUM"],
+                        "description": "Tier options: BASIC for basic, PREMIUM for premium.",
+                    },
+                },
+            },
+        }
+
+        result = enricher.enrich(spec)
+        description = result["components"]["schemas"]["TestTierType"]["description"]
+
+        assert "BASIC" not in description
+        assert "PREMIUM" not in description
+        assert "STANDARD" in description
+        assert "ADVANCED" in description
+
+
+class TestCLIExampleTransformation:
+    """Test CLI example transformation."""
+
+    def test_cli_example_basic_to_standard(self, enricher, spec_with_cli_examples):
+        """Test CLI examples are updated from basic to standard."""
+        result = enricher.enrich(spec_with_cli_examples)
+        example_cmd = result["components"]["schemas"]["TestSchema"]["x-ves-minimum-configuration"][
+            "example_command"
+        ]
+
+        assert "subscription_basic_tier" not in example_cmd
+        assert "subscription_standard_tier" in example_cmd
+
+    def test_cli_example_stats_updated(self, enricher, spec_with_cli_examples):
+        """Test CLI example stats are updated."""
+        enricher.enrich(spec_with_cli_examples)
+        stats = enricher.get_stats()
+
+        assert stats["cli_examples_fixed"] >= 1
+
+    def test_cli_example_premium_to_advanced(self, enricher):
+        """Test CLI examples with premium are updated to advanced."""
+        spec = {
+            "components": {
+                "schemas": {
+                    "TestSchema": {
+                        "type": "object",
+                        "x-ves-minimum-configuration": {
+                            "example_command": "xcsh set subscription_premium_tier --name test",
+                        },
+                    },
+                },
+            },
+        }
+
+        result = enricher.enrich(spec)
+        example_cmd = result["components"]["schemas"]["TestSchema"]["x-ves-minimum-configuration"][
+            "example_command"
+        ]
+
+        assert "subscription_premium_tier" not in example_cmd
+        assert "subscription_advanced_tier" in example_cmd
+
+
+class TestPatternMatching:
+    """Test schema pattern matching."""
+
+    def test_matches_addon_service_tier_type(self, enricher):
+        """Test pattern matches AddonServiceTierType schemas."""
+        assert enricher._matches_tier_pattern("schemaAddonServiceTierType")  # noqa: SLF001
+        assert enricher._matches_tier_pattern("pbacAddonServiceTierType")  # noqa: SLF001
+        assert enricher._matches_tier_pattern("SomeAddonServiceTierType")  # noqa: SLF001
+
+    def test_matches_tier_type(self, enricher):
+        """Test pattern matches TierType schemas."""
+        assert enricher._matches_tier_pattern("SomeTierType")  # noqa: SLF001
+        assert enricher._matches_tier_pattern("SubscriptionTierType")  # noqa: SLF001
+
+    def test_does_not_match_non_tier_schemas(self, enricher):
+        """Test pattern does not match non-tier schemas."""
+        assert not enricher._matches_tier_pattern("UserProfile")  # noqa: SLF001
+        assert not enricher._matches_tier_pattern("LoadBalancerConfig")  # noqa: SLF001
+        assert not enricher._matches_tier_pattern("TierSettings")  # noqa: SLF001
+
+
+class TestEdgeCases:
+    """Test edge cases."""
+
+    def test_empty_enum(self, enricher):
+        """Test handling of empty enum."""
+        spec = {
+            "components": {
+                "schemas": {
+                    "schemaAddonServiceTierType": {
+                        "type": "string",
+                        "enum": [],
+                    },
+                },
+            },
+        }
+
+        result = enricher.enrich(spec)
+        assert result["components"]["schemas"]["schemaAddonServiceTierType"]["enum"] == []
+
+    def test_no_enum_field(self, enricher):
+        """Test handling of schema without enum field."""
+        spec = {
+            "components": {
+                "schemas": {
+                    "schemaAddonServiceTierType": {
+                        "type": "string",
+                    },
+                },
+            },
+        }
+
+        result = enricher.enrich(spec)
+        assert "enum" not in result["components"]["schemas"]["schemaAddonServiceTierType"]
+
+    def test_empty_spec(self, enricher):
+        """Test handling of empty spec."""
+        spec = {}
+        result = enricher.enrich(spec)
+        assert result == {}
+
+    def test_no_components(self, enricher):
+        """Test handling of spec without components."""
+        spec = {"info": {"title": "Test API"}}
+        result = enricher.enrich(spec)
+        assert result == {"info": {"title": "Test API"}}
+
+    def test_no_schemas(self, enricher):
+        """Test handling of spec without schemas."""
+        spec = {"components": {"responses": {}}}
+        result = enricher.enrich(spec)
+        assert result == {"components": {"responses": {}}}
+
+
+class TestConfigurationIntegration:
+    """Test configuration file integration."""
+
+    def test_custom_transformations_from_config(self):
+        """Test that custom transformations can be loaded from config."""
+        # This test verifies the enricher can use config-based transformations
+        enricher = DeprecatedTierEnricher()
+
+        # Default transformations should be loaded
+        assert "BASIC" in enricher.transformations
+        assert "PREMIUM" in enricher.transformations
+        assert enricher.transformations["BASIC"] == "STANDARD"
+        assert enricher.transformations["PREMIUM"] == "ADVANCED"


### PR DESCRIPTION
## Summary

Resolves #164 - Implements deprecated tier transformation to convert legacy subscription tier values to their current equivalents in OpenAPI specification enum schemas.

### Tier Transformations
- **BASIC → STANDARD** (legacy tier replaced)
- **PREMIUM → ADVANCED** (legacy tier replaced)
- **NO_TIER** preserved as foundational tier

### Valid Tiers After Transformation
- `NO_TIER` - Foundational/not applicable
- `STANDARD` - Base subscription tier
- `ADVANCED` - Premium subscription tier

## Changes

- Add `DeprecatedTierEnricher` class with pattern matching for tier schemas
- Add `deprecated_tiers` configuration section to `config/enrichment.yaml`
- Integrate enricher into pipeline (step 0, before branding)
- Add 25 unit tests covering transformation logic and edge cases
- Export enricher from `scripts/utils/__init__.py`

## Configuration

The enricher is configured via `config/enrichment.yaml`:

```yaml
deprecated_tiers:
  enabled: true
  patterns:
    - ".*AddonServiceTierType$"
    - ".*TierType$"
  transformations:
    BASIC: "STANDARD"
    PREMIUM: "ADVANCED"
  valid_tiers:
    - "NO_TIER"
    - "STANDARD"
    - "ADVANCED"
```

## Test plan

- [x] Run unit tests (25/25 passed)
- [x] Verify pipeline execution (270 specs processed)
- [x] Spectral linting passed (40/40 specs)
- [x] All pre-commit hooks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)