### PR TITLE
docs: add TenantType to Subscription Tier mapping documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,21 @@ Pattern: `f5xc_{feature}_{tier}`
 | `FREEMIUM` | Free tenant (no custom domain) |
 | `ENTERPRISE` | Enterprise tenant (has custom domain) |
 
+#### TenantType to Subscription Tier Mapping
+
+The `tenant_type` field in the API response maps to subscription tier access:
+
+| TenantType | Subscription Tier | Feature Access |
+|------------|-------------------|----------------|
+| `FREEMIUM` | **Standard** | Base tier features only |
+| `ENTERPRISE` | **Advanced** | Full feature access including advanced capabilities |
+
+**API Endpoint**: `GET /api/web/namespaces/system/usage_plans/current`
+
+**Response field**: `plans[].tenant_type`
+
+> **Implementation Note**: When determining subscription tier from API responses, map `ENTERPRISE` → "Advanced" and `FREEMIUM` → "Standard". For unknown values, default to "Standard" for fail-safe behavior. See [xcsh implementation](https://github.com/robinmordasiewicz/xcsh/blob/main/pkg/subscription/client.go#L411-L422) for reference.
+
 ### Activation Types
 
 | Type | Description |


### PR DESCRIPTION
## Summary

Documents the explicit mapping between API `tenant_type` values and user-facing subscription tier names, filling a gap in the documentation that required empirical discovery.

## Changes

Added a new subsection **"TenantType to Subscription Tier Mapping"** that documents:

| TenantType | Subscription Tier | Feature Access |
|------------|-------------------|----------------|
| `FREEMIUM` | **Standard** | Base tier features only |
| `ENTERPRISE` | **Advanced** | Full feature access |

## Discovery Context

This mapping was discovered while implementing subscription tier detection for the [xcsh CLI](https://github.com/robinmordasiewicz/xcsh). The API returns `tenant_type` values but there was no documentation explaining how these map to the Standard/Advanced tier naming convention used throughout the platform.

## Implementation Reference

- **xcsh implementation**: [`determineTierFromTenantType()`](https://github.com/robinmordasiewicz/xcsh/blob/main/pkg/subscription/client.go#L411-L422)
- **Related PR**: robinmordasiewicz/xcsh#315

## Test Plan

- [x] README renders correctly with new documentation
- [x] Links to external references are valid

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)