### PR TITLE
feat: Add readOnly annotations for API-computed fields

### DIFF
--- a/config/readonly_fields.yaml
+++ b/config/readonly_fields.yaml
@@ -1,0 +1,77 @@
+# Read-Only Fields Configuration
+# Fields that are computed by the F5 XC API and should not be set by clients
+#
+# These fields get `readOnly: true` added to their schema definitions,
+# following the OpenAPI 3.0 standard for marking server-computed fields.
+
+version: "1.0.0"
+description: >
+  API-computed fields that should be marked as readOnly in OpenAPI schemas.
+  Downstream tooling (e.g., xcsh CLI) can use this to automatically exclude
+  these fields from create/update request payloads.
+
+# Metadata fields found in most resource schemas
+# These are set by the API server, not by clients
+metadata_fields:
+  tenant:
+    description: "Set by API from authentication context"
+    reason: "Determined by the authenticated user's tenant"
+
+  uid:
+    description: "Generated unique identifier by API"
+    reason: "Server-generated UUID for the resource"
+
+  kind:
+    description: "Set by API based on object type"
+    reason: "Automatically set based on resource type"
+
+  creation_timestamp:
+    description: "Set by server on object creation"
+    reason: "Server timestamp when resource was created"
+
+  modification_timestamp:
+    description: "Updated by server on each modification"
+    reason: "Server timestamp of last modification"
+
+  creator_id:
+    description: "Set by API from authentication context"
+    reason: "ID of the user who created the resource"
+
+  creator_class:
+    description: "Set by API from authentication context"
+    reason: "Classification of the creator (user, service, etc.)"
+
+  object_index:
+    description: "Internal index maintained by API"
+    reason: "Server-maintained ordering index"
+
+  owner_view:
+    description: "Set by API based on permissions"
+    reason: "Determined by resource ownership hierarchy"
+
+# ObjectRef types have these computed fields
+# These are auto-populated when referencing other objects
+object_ref_fields:
+  tenant:
+    description: "Auto-populated for object references from context"
+    reason: "Inherited from referencing resource's tenant"
+
+  uid:
+    description: "Auto-populated for object references by API"
+    reason: "Resolved from the referenced object"
+
+  kind:
+    description: "Auto-populated for object references based on target type"
+    reason: "Set based on the type of referenced object"
+
+# Schema name patterns that indicate ObjectRef types
+object_ref_patterns:
+  - "ObjectRefType"
+  - ".*ObjectRef$"
+  - ".*Ref$"
+
+# Schema name patterns that indicate metadata containers
+metadata_patterns:
+  - "ObjectMetaType"
+  - ".*MetadataType$"
+  - "SystemMetadata"

--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -79,6 +79,7 @@ from scripts.utils import (
     GrammarImprover,
     MinimumConfigurationEnricher,
     OperationMetadataEnricher,
+    ReadOnlyEnricher,
     SchemaFixer,
     TagGenerator,
     ValidationEnricher,
@@ -280,6 +281,11 @@ def enrich_spec(spec: dict[str, Any], config: dict) -> tuple[dict[str, Any], dic
     spec = minimum_config_enricher.enrich_spec(spec)
     min_config_stats = minimum_config_enricher.get_stats()
 
+    # 16. ReadOnly field enrichment (mark API-computed fields as readOnly)
+    readonly_enricher = ReadOnlyEnricher()
+    spec = readonly_enricher.enrich_spec(spec)
+    readonly_stats = readonly_enricher.get_stats()
+
     # Close grammar improver resources
     grammar_improver.close()
 
@@ -303,6 +309,9 @@ def enrich_spec(spec: dict[str, Any], config: dict) -> tuple[dict[str, Any], dic
         "cli_examples_generated": op_stats.get("examples_generated", 0),
         "side_effects_documented": op_stats.get("side_effects_documented", 0),
         "minimum_configs_added": min_config_stats.get("minimum_configs_added", 0),
+        "readonly_fields_marked": readonly_stats.get("total_fields_marked", 0),
+        "readonly_metadata_schemas": readonly_stats.get("metadata_schemas_matched", 0),
+        "readonly_objectref_schemas": readonly_stats.get("object_ref_schemas_matched", 0),
     }
 
 

--- a/scripts/utils/__init__.py
+++ b/scripts/utils/__init__.py
@@ -16,6 +16,7 @@ from .field_metadata_enricher import FieldMetadataEnricher
 from .grammar import GrammarImprover
 from .minimum_configuration_enricher import MinimumConfigurationEnricher
 from .operation_metadata_enricher import OperationMetadataEnricher
+from .readonly_enricher import ReadOnlyEnricher
 from .schema_fixer import SchemaFixer
 from .tag_generator import TagGenerator
 from .validation_enricher import ValidationEnricher
@@ -41,6 +42,7 @@ __all__ = [
     "GrammarImprover",
     "MinimumConfigurationEnricher",
     "OperationMetadataEnricher",
+    "ReadOnlyEnricher",
     "SchemaFixer",
     "TagGenerator",
     "ValidationEnricher",

--- a/scripts/utils/readonly_enricher.py
+++ b/scripts/utils/readonly_enricher.py
@@ -1,0 +1,328 @@
+"""ReadOnly Field Enricher for OpenAPI specifications.
+
+Adds `readOnly: true` to API-computed fields following the OpenAPI 3.0 standard.
+These fields are server-generated and should not be set by clients.
+
+Downstream tooling (e.g., xcsh CLI) can use this to automatically exclude
+these fields from create/update request payloads.
+"""
+
+import contextlib
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+@dataclass
+class ReadOnlyStats:
+    """Statistics from readOnly field enrichment."""
+
+    metadata_fields_marked: int = 0
+    object_ref_fields_marked: int = 0
+    schemas_processed: int = 0
+    schemas_matched: int = 0
+    metadata_schemas_matched: int = 0
+    object_ref_schemas_matched: int = 0
+    fields_by_name: dict[str, int] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert stats to dictionary."""
+        return {
+            "metadata_fields_marked": self.metadata_fields_marked,
+            "object_ref_fields_marked": self.object_ref_fields_marked,
+            "total_fields_marked": self.metadata_fields_marked + self.object_ref_fields_marked,
+            "schemas_processed": self.schemas_processed,
+            "schemas_matched": self.schemas_matched,
+            "metadata_schemas_matched": self.metadata_schemas_matched,
+            "object_ref_schemas_matched": self.object_ref_schemas_matched,
+            "fields_by_name": self.fields_by_name,
+        }
+
+
+class ReadOnlyEnricher:
+    """Enricher that adds readOnly annotations to API-computed fields.
+
+    Identifies fields that are computed by the F5 XC API server and marks them
+    with `readOnly: true` following OpenAPI 3.0 standard.
+
+    Target field categories:
+    1. Metadata fields (tenant, uid, kind, timestamps, creator info, etc.)
+    2. ObjectRef fields (auto-populated reference fields)
+
+    Configuration-driven from readonly_fields.yaml.
+    Preserves existing readOnly values (never overwrites).
+    """
+
+    def __init__(self, config_path: Path | None = None) -> None:
+        """Initialize enricher with readOnly fields configuration.
+
+        Args:
+            config_path: Path to readonly_fields.yaml config.
+                        Defaults to config/readonly_fields.yaml.
+        """
+        if config_path is None:
+            config_path = Path(__file__).parent.parent.parent / "config" / "readonly_fields.yaml"
+
+        self.config_path = config_path
+        self.metadata_fields: dict[str, dict[str, str]] = {}
+        self.object_ref_fields: dict[str, dict[str, str]] = {}
+        self.metadata_patterns: list[re.Pattern] = []
+        self.object_ref_patterns: list[re.Pattern] = []
+        self.stats = ReadOnlyStats()
+
+        self._load_config()
+
+    def _load_config(self) -> None:
+        """Load readOnly field configuration from YAML config."""
+        if not self.config_path.exists():
+            self._use_default_config()
+            return
+
+        try:
+            with self.config_path.open() as f:
+                config = yaml.safe_load(f) or {}
+
+            self.metadata_fields = config.get("metadata_fields", {})
+            self.object_ref_fields = config.get("object_ref_fields", {})
+
+            # Compile schema name patterns
+            self.metadata_patterns = self._compile_patterns(
+                config.get("metadata_patterns", []),
+            )
+            self.object_ref_patterns = self._compile_patterns(
+                config.get("object_ref_patterns", []),
+            )
+
+        except Exception:
+            self._use_default_config()
+
+    def _compile_patterns(self, pattern_strings: list[str]) -> list[re.Pattern]:
+        """Compile a list of regex pattern strings.
+
+        Args:
+            pattern_strings: List of regex pattern strings
+
+        Returns:
+            List of compiled regex patterns (invalid patterns are skipped)
+        """
+        compiled: list[re.Pattern] = []
+        for pattern_str in pattern_strings:
+            with contextlib.suppress(re.error):
+                compiled.append(re.compile(pattern_str))
+        return compiled
+
+    def _use_default_config(self) -> None:
+        """Use built-in default readOnly field configuration."""
+        self.metadata_fields = {
+            "tenant": {"description": "Set by API from authentication context"},
+            "uid": {"description": "Generated unique identifier by API"},
+            "kind": {"description": "Set by API based on object type"},
+            "creation_timestamp": {"description": "Set by server on object creation"},
+            "modification_timestamp": {"description": "Updated by server on each modification"},
+            "creator_id": {"description": "Set by API from authentication context"},
+            "creator_class": {"description": "Set by API from authentication context"},
+            "object_index": {"description": "Internal index maintained by API"},
+            "owner_view": {"description": "Set by API based on permissions"},
+        }
+
+        self.object_ref_fields = {
+            "tenant": {"description": "Auto-populated for object references from context"},
+            "uid": {"description": "Auto-populated for object references by API"},
+            "kind": {"description": "Auto-populated for object references based on target type"},
+        }
+
+        self.metadata_patterns = [
+            re.compile(r"ObjectMetaType"),
+            re.compile(r".*MetadataType$"),
+            re.compile(r"SystemMetadata"),
+        ]
+
+        self.object_ref_patterns = [
+            re.compile(r"ObjectRefType"),
+            re.compile(r".*ObjectRef$"),
+            re.compile(r".*Ref$"),
+        ]
+
+    def enrich_spec(self, spec: dict[str, Any]) -> dict[str, Any]:
+        """Enrich OpenAPI specification with readOnly annotations.
+
+        Args:
+            spec: OpenAPI specification dictionary
+
+        Returns:
+            Specification with readOnly annotations added to computed fields
+        """
+        # Reset stats for this enrichment run
+        self.stats = ReadOnlyStats()
+
+        # Process schemas in components
+        if "components" in spec and "schemas" in spec["components"]:
+            spec["components"]["schemas"] = self._process_schemas(
+                spec["components"]["schemas"],
+            )
+
+        return spec
+
+    def _process_schemas(self, schemas: dict[str, Any]) -> dict[str, Any]:
+        """Process all schemas and add readOnly where appropriate.
+
+        Args:
+            schemas: Dictionary of schema definitions
+
+        Returns:
+            Processed schemas with readOnly annotations
+        """
+        result = {}
+
+        for schema_name, schema in schemas.items():
+            self.stats.schemas_processed += 1
+            result[schema_name] = self._process_schema(schema, schema_name)
+
+        return result
+
+    def _process_schema(self, schema: dict[str, Any], schema_name: str) -> dict[str, Any]:
+        """Process a single schema and add readOnly to computed fields.
+
+        Args:
+            schema: Schema definition
+            schema_name: Name of the schema
+
+        Returns:
+            Processed schema
+        """
+        if not isinstance(schema, dict):
+            return schema
+
+        result = schema.copy()
+
+        # Check if this schema matches metadata or ObjectRef patterns
+        is_metadata_schema = self._matches_patterns(schema_name, self.metadata_patterns)
+        is_object_ref_schema = self._matches_patterns(schema_name, self.object_ref_patterns)
+
+        if is_metadata_schema or is_object_ref_schema:
+            self.stats.schemas_matched += 1
+            if is_metadata_schema:
+                self.stats.metadata_schemas_matched += 1
+            if is_object_ref_schema:
+                self.stats.object_ref_schemas_matched += 1
+
+        # Process properties if present
+        if "properties" in result and isinstance(result["properties"], dict):
+            result["properties"] = self._process_properties(
+                result["properties"],
+                schema_name,
+                is_metadata_schema,
+                is_object_ref_schema,
+            )
+
+        # Recursively process nested schemas
+        for key in ["items", "additionalProperties"]:
+            if key in result and isinstance(result[key], dict):
+                result[key] = self._process_schema(result[key], f"{schema_name}.{key}")
+
+        for key in ["oneOf", "allOf", "anyOf"]:
+            if key in result and isinstance(result[key], list):
+                result[key] = [
+                    self._process_schema(item, f"{schema_name}.{key}[{i}]")
+                    for i, item in enumerate(result[key])
+                ]
+
+        return result
+
+    def _matches_patterns(self, schema_name: str, patterns: list[re.Pattern]) -> bool:
+        """Check if schema name matches any of the given patterns.
+
+        Args:
+            schema_name: Name of the schema to check
+            patterns: List of compiled regex patterns
+
+        Returns:
+            True if schema name matches any pattern
+        """
+        return any(pattern.search(schema_name) for pattern in patterns)
+
+    def _process_properties(
+        self,
+        properties: dict[str, Any],
+        schema_name: str,
+        is_metadata_schema: bool,
+        is_object_ref_schema: bool,
+    ) -> dict[str, Any]:
+        """Process properties and add readOnly to computed fields.
+
+        Args:
+            properties: Properties dictionary from schema
+            schema_name: Name of parent schema
+            is_metadata_schema: Whether parent schema matches metadata patterns
+            is_object_ref_schema: Whether parent schema matches ObjectRef patterns
+
+        Returns:
+            Processed properties dictionary
+        """
+        result = {}
+
+        for prop_name, prop_schema in properties.items():
+            if not isinstance(prop_schema, dict):
+                result[prop_name] = prop_schema
+                continue
+
+            result[prop_name] = prop_schema.copy()
+
+            # Check if this field should be marked readOnly
+            should_mark = False
+            is_metadata_field = False
+
+            # Check metadata fields (for metadata schemas)
+            if is_metadata_schema and prop_name in self.metadata_fields:
+                should_mark = True
+                is_metadata_field = True
+
+            # Check ObjectRef fields (for ObjectRef schemas)
+            if is_object_ref_schema and prop_name in self.object_ref_fields:
+                should_mark = True
+                is_metadata_field = False
+
+            # Apply readOnly if appropriate and not already set
+            if should_mark and "readOnly" not in result[prop_name]:
+                result[prop_name]["readOnly"] = True
+
+                # Update stats
+                if is_metadata_field:
+                    self.stats.metadata_fields_marked += 1
+                else:
+                    self.stats.object_ref_fields_marked += 1
+
+                # Track by field name
+                if prop_name not in self.stats.fields_by_name:
+                    self.stats.fields_by_name[prop_name] = 0
+                self.stats.fields_by_name[prop_name] += 1
+
+            # Recursively process nested properties
+            if "properties" in result[prop_name]:
+                nested_is_metadata = self._matches_patterns(
+                    f"{schema_name}.{prop_name}",
+                    self.metadata_patterns,
+                )
+                nested_is_ref = self._matches_patterns(
+                    f"{schema_name}.{prop_name}",
+                    self.object_ref_patterns,
+                )
+                result[prop_name]["properties"] = self._process_properties(
+                    result[prop_name]["properties"],
+                    f"{schema_name}.{prop_name}",
+                    nested_is_metadata,
+                    nested_is_ref,
+                )
+
+        return result
+
+    def get_stats(self) -> dict[str, Any]:
+        """Get enrichment statistics.
+
+        Returns:
+            Dictionary with enrichment metrics
+        """
+        return self.stats.to_dict()

--- a/tests/test_readonly_enricher.py
+++ b/tests/test_readonly_enricher.py
@@ -1,0 +1,426 @@
+"""Unit tests for ReadOnlyEnricher.
+
+Tests the readOnly: true annotation added to API-computed fields
+for downstream tooling (e.g., xcsh CLI).
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scripts.utils.readonly_enricher import ReadOnlyEnricher, ReadOnlyStats
+
+
+class TestReadOnlyStats:
+    """Test ReadOnlyStats dataclass."""
+
+    def test_default_values(self) -> None:
+        """Verify default stat values are zero."""
+        stats = ReadOnlyStats()
+        assert stats.metadata_fields_marked == 0
+        assert stats.object_ref_fields_marked == 0
+        assert stats.schemas_processed == 0
+        assert stats.schemas_matched == 0
+
+    def test_to_dict_contains_all_fields(self) -> None:
+        """Verify to_dict includes all stat fields."""
+        stats = ReadOnlyStats()
+        result = stats.to_dict()
+
+        assert "metadata_fields_marked" in result
+        assert "object_ref_fields_marked" in result
+        assert "total_fields_marked" in result
+        assert "schemas_processed" in result
+        assert "schemas_matched" in result
+        assert "fields_by_name" in result
+
+    def test_to_dict_calculates_total(self) -> None:
+        """Verify to_dict calculates total_fields_marked correctly."""
+        stats = ReadOnlyStats()
+        stats.metadata_fields_marked = 5
+        stats.object_ref_fields_marked = 3
+
+        result = stats.to_dict()
+        assert result["total_fields_marked"] == 8
+
+
+class TestReadOnlyEnricherConfig:
+    """Test ReadOnlyEnricher configuration loading."""
+
+    @pytest.fixture
+    def config_path(self) -> Path:
+        """Get path to readonly_fields.yaml config file."""
+        return Path(__file__).parent.parent / "config" / "readonly_fields.yaml"
+
+    def test_config_file_exists(self, config_path: Path) -> None:
+        """Verify configuration file exists."""
+        assert config_path.exists(), f"Config file not found: {config_path}"
+
+    def test_config_is_valid_yaml(self, config_path: Path) -> None:
+        """Verify configuration file is valid YAML."""
+        with config_path.open() as f:
+            config = yaml.safe_load(f)
+        assert config is not None
+
+    def test_config_has_metadata_fields(self, config_path: Path) -> None:
+        """Verify config has metadata_fields key."""
+        with config_path.open() as f:
+            config = yaml.safe_load(f)
+        assert "metadata_fields" in config
+
+    def test_config_has_object_ref_fields(self, config_path: Path) -> None:
+        """Verify config has object_ref_fields key."""
+        with config_path.open() as f:
+            config = yaml.safe_load(f)
+        assert "object_ref_fields" in config
+
+    def test_config_has_patterns(self, config_path: Path) -> None:
+        """Verify config has pattern definitions."""
+        with config_path.open() as f:
+            config = yaml.safe_load(f)
+        assert "metadata_patterns" in config
+        assert "object_ref_patterns" in config
+
+    def test_config_metadata_fields_are_complete(self, config_path: Path) -> None:
+        """Verify all expected metadata fields are configured."""
+        with config_path.open() as f:
+            config = yaml.safe_load(f)
+
+        expected_fields = [
+            "tenant",
+            "uid",
+            "kind",
+            "creation_timestamp",
+            "modification_timestamp",
+            "creator_id",
+            "creator_class",
+            "object_index",
+            "owner_view",
+        ]
+
+        for field_name in expected_fields:
+            assert field_name in config["metadata_fields"], f"Missing field: {field_name}"
+
+
+class TestReadOnlyEnricherInit:
+    """Test ReadOnlyEnricher initialization."""
+
+    def test_init_with_default_config(self) -> None:
+        """Verify enricher initializes with default config path."""
+        enricher = ReadOnlyEnricher()
+        assert enricher.config_path.name == "readonly_fields.yaml"
+
+    def test_init_loads_metadata_fields(self) -> None:
+        """Verify enricher loads metadata fields from config."""
+        enricher = ReadOnlyEnricher()
+        assert "tenant" in enricher.metadata_fields
+        assert "uid" in enricher.metadata_fields
+        assert "kind" in enricher.metadata_fields
+
+    def test_init_loads_object_ref_fields(self) -> None:
+        """Verify enricher loads object ref fields from config."""
+        enricher = ReadOnlyEnricher()
+        assert "tenant" in enricher.object_ref_fields
+        assert "uid" in enricher.object_ref_fields
+        assert "kind" in enricher.object_ref_fields
+
+    def test_init_compiles_patterns(self) -> None:
+        """Verify enricher compiles regex patterns."""
+        enricher = ReadOnlyEnricher()
+        assert len(enricher.metadata_patterns) > 0
+        assert len(enricher.object_ref_patterns) > 0
+
+
+class TestReadOnlyEnricherEnrich:
+    """Test ReadOnlyEnricher spec enrichment."""
+
+    @pytest.fixture
+    def enricher(self) -> ReadOnlyEnricher:
+        """Create enricher instance."""
+        return ReadOnlyEnricher()
+
+    def test_enrich_empty_spec(self, enricher: ReadOnlyEnricher) -> None:
+        """Verify enricher handles empty spec."""
+        spec = {}
+        result = enricher.enrich_spec(spec)
+        assert result == {}
+
+    def test_enrich_spec_without_schemas(self, enricher: ReadOnlyEnricher) -> None:
+        """Verify enricher handles spec without schemas."""
+        spec = {"info": {"title": "Test API"}}
+        result = enricher.enrich_spec(spec)
+        assert result == spec
+
+    def test_enrich_metadata_schema(self, enricher: ReadOnlyEnricher) -> None:
+        """Verify enricher marks metadata fields as readOnly."""
+        spec = {
+            "components": {
+                "schemas": {
+                    "ObjectMetaType": {
+                        "type": "object",
+                        "properties": {
+                            "tenant": {"type": "string"},
+                            "uid": {"type": "string"},
+                            "kind": {"type": "string"},
+                            "name": {"type": "string"},  # Not a computed field
+                        },
+                    },
+                },
+            },
+        }
+
+        result = enricher.enrich_spec(spec)
+
+        props = result["components"]["schemas"]["ObjectMetaType"]["properties"]
+        assert props["tenant"].get("readOnly") is True
+        assert props["uid"].get("readOnly") is True
+        assert props["kind"].get("readOnly") is True
+        assert "readOnly" not in props["name"]  # Should not be marked
+
+    def test_enrich_object_ref_schema(self, enricher: ReadOnlyEnricher) -> None:
+        """Verify enricher marks ObjectRef fields as readOnly."""
+        spec = {
+            "components": {
+                "schemas": {
+                    "NetworkObjectRef": {
+                        "type": "object",
+                        "properties": {
+                            "tenant": {"type": "string"},
+                            "uid": {"type": "string"},
+                            "kind": {"type": "string"},
+                            "name": {"type": "string"},
+                            "namespace": {"type": "string"},
+                        },
+                    },
+                },
+            },
+        }
+
+        result = enricher.enrich_spec(spec)
+
+        props = result["components"]["schemas"]["NetworkObjectRef"]["properties"]
+        assert props["tenant"].get("readOnly") is True
+        assert props["uid"].get("readOnly") is True
+        assert props["kind"].get("readOnly") is True
+        assert "readOnly" not in props["name"]  # User-provided
+        assert "readOnly" not in props["namespace"]  # User-provided
+
+    def test_preserves_existing_readonly(self, enricher: ReadOnlyEnricher) -> None:
+        """Verify enricher does not overwrite existing readOnly values."""
+        spec = {
+            "components": {
+                "schemas": {
+                    "ObjectMetaType": {
+                        "type": "object",
+                        "properties": {
+                            "tenant": {"type": "string", "readOnly": False},
+                        },
+                    },
+                },
+            },
+        }
+
+        result = enricher.enrich_spec(spec)
+
+        props = result["components"]["schemas"]["ObjectMetaType"]["properties"]
+        # Should preserve the existing False value
+        assert props["tenant"]["readOnly"] is False
+
+    def test_enrich_non_matching_schema(self, enricher: ReadOnlyEnricher) -> None:
+        """Verify enricher does not mark fields in non-matching schemas."""
+        spec = {
+            "components": {
+                "schemas": {
+                    "HttpLoadBalancer": {
+                        "type": "object",
+                        "properties": {
+                            "tenant": {"type": "string"},  # Same field name
+                            "name": {"type": "string"},
+                        },
+                    },
+                },
+            },
+        }
+
+        result = enricher.enrich_spec(spec)
+
+        props = result["components"]["schemas"]["HttpLoadBalancer"]["properties"]
+        # Should NOT be marked because schema doesn't match patterns
+        assert "readOnly" not in props["tenant"]
+        assert "readOnly" not in props["name"]
+
+    def test_stats_tracking(self, enricher: ReadOnlyEnricher) -> None:
+        """Verify enricher tracks statistics correctly."""
+        spec = {
+            "components": {
+                "schemas": {
+                    "ObjectMetaType": {
+                        "type": "object",
+                        "properties": {
+                            "tenant": {"type": "string"},
+                            "uid": {"type": "string"},
+                        },
+                    },
+                    "SiteRef": {
+                        "type": "object",
+                        "properties": {
+                            "tenant": {"type": "string"},
+                            "uid": {"type": "string"},
+                        },
+                    },
+                },
+            },
+        }
+
+        enricher.enrich_spec(spec)
+        stats = enricher.get_stats()
+
+        assert stats["schemas_processed"] == 2
+        assert stats["schemas_matched"] >= 2
+        assert stats["total_fields_marked"] >= 4
+
+
+class TestReadOnlyEnricherPatterns:
+    """Test schema name pattern matching."""
+
+    @pytest.fixture
+    def enricher(self) -> ReadOnlyEnricher:
+        """Create enricher instance."""
+        return ReadOnlyEnricher()
+
+    @pytest.mark.parametrize(
+        "schema_name",
+        [
+            "ObjectMetaType",
+            "SomeMetadataType",
+            "SystemMetadata",
+        ],
+    )
+    def test_metadata_patterns_match(self, enricher: ReadOnlyEnricher, schema_name: str) -> None:
+        """Verify metadata patterns match expected schema names."""
+        assert enricher._matches_patterns(schema_name, enricher.metadata_patterns)  # noqa: SLF001
+
+    @pytest.mark.parametrize(
+        "schema_name",
+        [
+            "ObjectRefType",
+            "NetworkObjectRef",
+            "SiteRef",
+            "NamespaceRef",
+        ],
+    )
+    def test_object_ref_patterns_match(self, enricher: ReadOnlyEnricher, schema_name: str) -> None:
+        """Verify ObjectRef patterns match expected schema names."""
+        assert enricher._matches_patterns(schema_name, enricher.object_ref_patterns)  # noqa: SLF001
+
+    @pytest.mark.parametrize(
+        "schema_name",
+        [
+            "HttpLoadBalancer",
+            "OriginPool",
+            "CreateRequest",
+            "GetResponse",
+        ],
+    )
+    def test_patterns_dont_match_regular_schemas(
+        self,
+        enricher: ReadOnlyEnricher,
+        schema_name: str,
+    ) -> None:
+        """Verify patterns don't match regular resource schemas."""
+        assert not enricher._matches_patterns(schema_name, enricher.metadata_patterns)  # noqa: SLF001
+        assert not enricher._matches_patterns(schema_name, enricher.object_ref_patterns)  # noqa: SLF001
+
+
+class TestReadOnlyEnricherIntegration:
+    """Integration tests for ReadOnlyEnricher."""
+
+    def test_enricher_is_exported(self) -> None:
+        """Verify ReadOnlyEnricher is exported from scripts.utils."""
+        from scripts.utils import ReadOnlyEnricher as ExportedEnricher  # noqa: PLC0415
+
+        assert ExportedEnricher is not None
+        assert ExportedEnricher.__name__ == "ReadOnlyEnricher"
+
+    def test_enricher_can_be_instantiated(self) -> None:
+        """Verify enricher can be instantiated without errors."""
+        from scripts.utils import ReadOnlyEnricher as ExportedEnricher  # noqa: PLC0415
+
+        enricher = ExportedEnricher()
+        assert enricher is not None
+
+    def test_enricher_with_complex_spec(self) -> None:
+        """Test enricher with a realistic complex spec structure."""
+        enricher = ReadOnlyEnricher()
+
+        spec = {
+            "openapi": "3.0.3",
+            "info": {"title": "Test API", "version": "1.0.0"},
+            "components": {
+                "schemas": {
+                    "ObjectMetaType": {
+                        "type": "object",
+                        "description": "Metadata for all objects",
+                        "properties": {
+                            "tenant": {"type": "string", "description": "Tenant ID"},
+                            "uid": {"type": "string", "description": "Unique identifier"},
+                            "kind": {"type": "string", "description": "Object kind"},
+                            "creation_timestamp": {"type": "string", "format": "date-time"},
+                            "modification_timestamp": {"type": "string", "format": "date-time"},
+                            "name": {"type": "string", "description": "Object name"},
+                            "labels": {"type": "object"},
+                        },
+                    },
+                    "VirtualHostRef": {
+                        "type": "object",
+                        "properties": {
+                            "tenant": {"type": "string"},
+                            "uid": {"type": "string"},
+                            "kind": {"type": "string"},
+                            "name": {"type": "string"},
+                            "namespace": {"type": "string"},
+                        },
+                    },
+                    "HttpLoadBalancer": {
+                        "type": "object",
+                        "properties": {
+                            "metadata": {"$ref": "#/components/schemas/ObjectMetaType"},
+                            "spec": {
+                                "type": "object",
+                                "properties": {
+                                    "domains": {"type": "array"},
+                                    "http": {"type": "object"},
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        }
+
+        result = enricher.enrich_spec(spec)
+        stats = enricher.get_stats()
+
+        # Verify ObjectMetaType computed fields are marked
+        meta_props = result["components"]["schemas"]["ObjectMetaType"]["properties"]
+        assert meta_props["tenant"].get("readOnly") is True
+        assert meta_props["uid"].get("readOnly") is True
+        assert meta_props["creation_timestamp"].get("readOnly") is True
+        assert "readOnly" not in meta_props["name"]  # User-provided
+        assert "readOnly" not in meta_props["labels"]  # User-provided
+
+        # Verify VirtualHostRef computed fields are marked
+        ref_props = result["components"]["schemas"]["VirtualHostRef"]["properties"]
+        assert ref_props["tenant"].get("readOnly") is True
+        assert ref_props["uid"].get("readOnly") is True
+        assert "readOnly" not in ref_props["name"]  # User-provided
+
+        # Verify HttpLoadBalancer is not affected
+        lb_props = result["components"]["schemas"]["HttpLoadBalancer"]["properties"]
+        assert "readOnly" not in lb_props.get("metadata", {})
+        assert "readOnly" not in lb_props.get("spec", {})
+
+        # Verify stats
+        assert stats["schemas_processed"] == 3
+        assert stats["total_fields_marked"] > 0


### PR DESCRIPTION
## Summary

Adds `readOnly: true` annotations to API-computed fields in OpenAPI schemas, following the OpenAPI 3.0 standard for marking server-generated fields.

## Changes

- **New enricher**: `scripts/utils/readonly_enricher.py` with `ReadOnlyEnricher` class
- **Configuration**: `config/readonly_fields.yaml` defining computed field patterns
- **Pipeline integration**: Added as step 16 in enrichment pipeline
- **Comprehensive tests**: 34 unit tests in `tests/test_readonly_enricher.py`

## Computed Fields Marked

**Metadata fields** (in schemas matching `*MetadataType`, `ObjectMetaType`, `SystemMetadata`):
- `tenant` - Set by API from authentication context
- `uid` - Generated unique identifier by API
- `kind` - Set by API based on object type
- `creation_timestamp` - Set by server on object creation
- `modification_timestamp` - Updated by server on each modification
- `creator_id` - Set by API from authentication context
- `creator_class` - Set by API from authentication context
- `object_index` - Internal index maintained by API
- `owner_view` - Set by API based on permissions

**ObjectRef fields** (in schemas matching `*ObjectRef`, `*Ref`, `ObjectRefType`):
- `tenant` - Auto-populated from context
- `uid` - Auto-populated by API
- `kind` - Auto-populated based on target type

## Benefits

- Downstream tooling (xcsh CLI) can automatically exclude these fields from create/update payloads
- Prevents user errors from attempting to set server-computed values
- Follows OpenAPI 3.0 standard for read-only field marking

## Test plan

- [x] All 34 unit tests pass
- [x] Pre-commit hooks pass (ruff, mypy, yamllint)
- [x] Pipeline integration verified
- [ ] CI checks pass

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)