### PR TITLE
fix: include ui_category in pipeline.py index generation

### DIFF
--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -1243,6 +1243,7 @@ def create_spec_index(domain_specs: dict[str, dict[str, Any]], version: str) -> 
             "is_preview": metadata.get("is_preview", False),
             "requires_tier": metadata.get("requires_tier", "Standard"),
             "domain_category": metadata.get("domain_category", "Other"),
+            "ui_category": metadata.get("ui_category", metadata.get("domain_category", "Other")),
             "aliases": metadata.get("aliases", []),
             "use_cases": metadata.get("use_cases", []),
             "related_domains": metadata.get("related_domains", []),


### PR DESCRIPTION
## Summary

Fixes the ui_category field appearing with null values in the released index.json.

## Problem

The previous PR #248 added ui_category to `merge_specs.py`, but the GitHub Actions workflow runs `pipeline.py` which has its own `create_spec_index` function. This meant the ui_category field was not being populated correctly.

## Solution

Added the ui_category field to `pipeline.py`'s `create_spec_index` function:

```python
"ui_category": metadata.get("ui_category", metadata.get("domain_category", "Other")),
```

This mirrors the fix in merge_specs.py and ensures the released index.json contains the correct ui_category values.

## Testing

After merging, the new release should show ui_category values like "Load Balancing", "DNS", "Security" instead of null.

Closes #246