### PR TITLE
feat: add root/master spec description enrichment

### DIFF
--- a/config/domain_descriptions.yaml
+++ b/config/domain_descriptions.yaml
@@ -1,6 +1,17 @@
 version: 1.0.0
 generated_at: '2025-12-30T16:30:46.645439+00:00'
 domains:
+  root:
+    source_patterns_hash: sha256:manual
+    short: F5 Distributed Cloud platform.
+    medium: Deploy and secure multi-cloud applications with load balancing, WAF, DNS, and
+      edge infrastructure services.
+    long: F5 Distributed Cloud delivers unified application services across multi-cloud,
+      edge, and hybrid environments. Deploy load balancers with origin pools and health
+      checks. Protect applications with web application firewall and bot defense. Manage
+      DNS zones with geographic routing. Provision cloud sites on AWS, Azure, and GCP.
+      Configure service policies, network security, and observability dashboards from a
+      single control plane.
   virtual:
     source_patterns_hash: sha256:1eead315c8572a28f35b7d560a4b36b65c970cef1e8ba428dca3e6dc9bdca5e1
     short: Configure load balancers and origin pools.

--- a/scripts/merge_specs.py
+++ b/scripts/merge_specs.py
@@ -18,6 +18,7 @@ from rich.console import Console
 from rich.progress import BarColumn, Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
 from rich.table import Table
 
+from scripts.utils.description_enricher import DescriptionEnricher
 from scripts.utils.domain_categorizer import (
     categorize_spec as categorize_spec_util,
 )
@@ -383,9 +384,13 @@ def create_master_spec(
     upstream_info: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     """Create a master specification combining all domains."""
+    # Load enriched description for root/master spec
+    enricher = DescriptionEnricher()
+    root_desc = enricher.get_description("root", tier="long")
+
     master = create_base_spec(
         title="F5 Distributed Cloud API",
-        description="Complete F5 Distributed Cloud API specification",
+        description=root_desc or "Complete F5 Distributed Cloud API specification",
         version=version,
         upstream_info=upstream_info,
     )

--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -1146,9 +1146,13 @@ def create_master_spec(domain_specs: dict[str, dict[str, Any]], version: str) ->
     Ensures operationId uniqueness across all domains by prefixing
     cross-domain duplicates with the domain name.
     """
+    # Load enriched description for root/master spec
+    enricher = DescriptionEnricher()
+    root_desc = enricher.get_description("root", tier="long")
+
     master = create_base_spec(
         title="F5 Distributed Cloud API",
-        description="Complete F5 Distributed Cloud API specification",
+        description=root_desc or "Complete F5 Distributed Cloud API specification",
         version=version,
     )
 

--- a/tests/test_description_enricher.py
+++ b/tests/test_description_enricher.py
@@ -261,3 +261,48 @@ class TestDescriptionValidation:
             desc = enricher.get_description(domain, tier="long")
             if desc:
                 assert len(desc) <= 500, f"Long description for {domain} exceeds 500 chars"
+
+
+class TestRootDescriptionEnrichment:
+    """Test root/master spec description enrichment."""
+
+    def test_root_description_exists(self, enricher):
+        """Test that root domain has descriptions configured."""
+        assert enricher.has_description("root") is True
+
+    def test_root_short_description(self, enricher):
+        """Test root short description is properly configured."""
+        desc = enricher.get_description("root", tier="short")
+        assert desc is not None
+        assert len(desc) <= 60
+        assert "F5" in desc or "API" in desc
+
+    def test_root_medium_description(self, enricher):
+        """Test root medium description is properly configured."""
+        desc = enricher.get_description("root", tier="medium")
+        assert desc is not None
+        assert len(desc) <= 150
+        # Should describe product capabilities
+        assert any(keyword in desc.lower() for keyword in ["multi-cloud", "application", "deploy"])
+
+    def test_root_long_description(self, enricher):
+        """Test root long description is substantial and informative."""
+        desc = enricher.get_description("root", tier="long")
+        assert desc is not None
+        assert len(desc) > 100  # Should be substantial
+        assert len(desc) <= 500
+        # Should mention key domains
+        assert any(keyword in desc.lower() for keyword in ["load balancing", "waf", "dns", "cdn"])
+
+    def test_root_all_descriptions(self, enricher):
+        """Test root has all description tiers configured."""
+        descs = enricher.get_all_descriptions("root")
+        assert descs is not None
+        assert "short" in descs
+        assert "medium" in descs
+        assert "long" in descs
+
+    def test_root_in_configured_domains(self, enricher):
+        """Test root is in the list of configured domains."""
+        domains = enricher.get_configured_domains()
+        assert "root" in domains


### PR DESCRIPTION
## Summary

The master spec (`openapi.json`) was bypassing the description enrichment pipeline that domain specs receive. This adds enrichment support for the root/master specification with product-focused descriptions.

## Changes

- Add `root` entry to `config/domain_descriptions.yaml` with tiered descriptions
- Update `pipeline.py` `create_master_spec()` to load enriched description
- Update `merge_specs.py` `create_master_spec()` to load enriched description
- Add 6 tests for root description enrichment

## Before/After

**Before:**
```json
{
  "info": {
    "description": "Complete F5 Distributed Cloud API specification"
  }
}
```

**After:**
```json
{
  "info": {
    "description": "F5 Distributed Cloud delivers unified application services across multi-cloud, edge, and hybrid environments. Deploy load balancers with origin pools and health checks. Protect applications with web application firewall and bot defense. Manage DNS zones with geographic routing. Provision cloud sites on AWS, Azure, and GCP. Configure service policies, network security, and observability dashboards from a single control plane."
  }
}
```

## Testing

- All 6 new root description tests pass
- Full pipeline runs successfully
- Pre-commit hooks pass

Closes #265

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)