### PR TITLE
refactor: add implicit context principle to programmatic LLM prompts

### DIFF
--- a/scripts/generate_descriptions.py
+++ b/scripts/generate_descriptions.py
@@ -382,15 +382,34 @@ Sample paths:
 Schemas: {schemas_str or "(none)"}
 
 ═══════════════════════════════════════════════════════════════════════════════
+IMPLICIT CONTEXT PRINCIPLE - Why These Rules Exist:
+
+This repository is `f5xc-api-enriched` - enriched F5 XC API specifications.
+From repository context alone, readers already know:
+• This is F5 XC content → "F5", "F5 XC", "XC", "Volterra" add zero information
+• This is API documentation → "API", "endpoint", "specification" add zero information
+• Every resource is an API → "REST", "HTTP endpoint" add zero information
+
+CHARACTER EFFICIENCY:
+Every character in short/medium descriptions must add NEW semantic value.
+Repeating what's already implied wastes limited character space.
+Mental test: "Does this word tell readers something they couldn't infer from context?"
+
+This principle drives ALL banned terms below - they fail the semantic value test.
+Understand WHY terms are banned (redundancy), not just WHAT is banned.
+
+═══════════════════════════════════════════════════════════════════════════════
 STRICT RULES - Violations cause INSTANT REJECTION:
 
-1. BANNED TERMS BY CATEGORY:
+1. BANNED TERMS BY CATEGORY (all fail implicit context test):
 
-   REDUNDANT (these ARE API specs - never state the obvious):
+   REDUNDANT (context implies these - zero semantic value):
    ✗ "API", "REST API", "endpoint", "specifications", "spec"
+   Why: Repository name includes "api" - readers already know this is API documentation
 
-   BRAND NAMES (never reference products):
+   BRAND NAMES (context implies these - zero semantic value):
    ✗ "F5", "F5 XC", "XC", "Distributed Cloud", "Volterra"
+   Why: Repository name includes "f5xc" - readers already know this is F5 XC content
 
    FILLER WORDS (use simpler alternatives):
    ✗ "utilize" → use "use"
@@ -1833,6 +1852,16 @@ DOMAIN-SPECIFIC GUIDANCE:
 
 NEVER use the word "{domain.replace("_", " ")}" in any description.
 Instead, use these synonyms: {synonyms_str}
+
+═══════════════════════════════════════════════════════════════════════════════
+IMPLICIT CONTEXT PRINCIPLE - Remember why terms are banned:
+
+Repository context (`f5xc-api-enriched`) already tells readers:
+• This is F5 XC → "F5", "XC", "Volterra" are redundant
+• This is API documentation → "API", "endpoint" are redundant
+• Every resource is an API → stating the obvious wastes characters
+
+Mental test: "Does this word add semantic value beyond what context implies?"
 
 ═══════════════════════════════════════════════════════════════════════════════
 FIX INSTRUCTIONS:


### PR DESCRIPTION
## Summary

Enhance the programmatic prompts in `generate_descriptions.py` with conceptual reasoning about WHY terms are banned, not just WHAT is banned.

## Changes

- Added **IMPLICIT CONTEXT PRINCIPLE** section to `build_prompt()`
- Enhanced BANNED TERMS section with "Why:" explanations  
- Added principle reminder to `build_refinement_prompt()`

## The Principle

Repository name `f5xc-api-enriched` already implies:
- This is **F5 XC** content → "F5", "XC", "Volterra" add zero information
- This is **API** documentation → "API", "endpoint" add zero information

**Mental test**: "Does this word tell readers something they couldn't infer from context?"

## Impact

- More consistent description generation from Claude
- Reduced retries due to style violations  
- Better understanding of WHY patterns are anti-patterns

Closes #288

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)