### PR TITLE
refactor: v3.0.0 major version - clean break x-f5xc-* namespace

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -237,25 +237,25 @@ make pre-commit-run      # Run all hooks manually
 
 Four OpenAPI extensions are added to schemas and specs:
 
-1. **x-ves-minimum-configuration** (schema-level)
+1. **x-f5xc-minimum-configuration** (schema-level)
    - Description of minimum viable configuration
    - Required fields list
    - Example YAML configuration
    - Example xcsh CLI command
    - Applied to ALL resource schemas (5 configured + auto-generated for others)
 
-2. **x-ves-cli-domain** (both schema and spec-level)
+2. **x-f5xc-cli-domain** (both schema and spec-level)
    - Domain classification (e.g., "virtual", "waf", "cdn")
    - At schema level: Resource classification
    - At spec level: Domain grouping metadata
    - Idempotent: Preserves existing values if present
 
-3. **x-ves-required-for** (field-level)
+3. **x-f5xc-required-for** (field-level)
    - Context-specific field requirements
    - Flags: minimum_config, create, update, read
    - Enables intelligent configuration generation
 
-4. **x-ves-cli-aliases** (schema-level)
+4. **x-f5xc-cli-aliases** (schema-level)
    - Alternative names for resources
    - Supports CLI command flexibility
    - Explicitly configured per resource
@@ -268,7 +268,7 @@ Four OpenAPI extensions are added to schemas and specs:
   - Uses DomainCategorizer for domain classification
 
 - **Stage 2 (Merge)**: add_domain_metadata_to_spec() adds spec-level metadata
-  - Spec info section gets x-ves-cli-domain from domain categorization
+  - Spec info section gets x-f5xc-cli-domain from domain categorization
   - Spec index includes CLI domain metadata
   - Idempotent: Never overwrites existing values
 
@@ -290,7 +290,7 @@ Four OpenAPI extensions are added to schemas and specs:
 
 **Addresses**:
 
-- Issue #267: x-ves-resource-metadata for IDE tooling
+- Issue #267: x-f5xc-resource-metadata for IDE tooling
 - Issue #268: Per-resource descriptions
 - Issue #269: Per-resource tier requirements
 - Issue #270: Resource dependency/relationship metadata

--- a/config/extension_registry.yaml
+++ b/config/extension_registry.yaml
@@ -7,11 +7,17 @@
 #
 # Consumers: f5xc-api-mcp, f5xc-xcsh, vscode-f5xc-tools
 #
-# Version: 2.0.0
+# Version: 3.0.0
 # Issue: #292
 # Released: 2026-01-04
+#
+# v3.0.0 Changes:
+# - Removed all backward compatibility code
+# - Migrated cli_metadata → x-f5xc-cli-metadata
+# - Added discovery extensions
+# - Consolidated category fields (removed domain_category, ui_category)
 
-version: "2.0"
+version: "3.0"
 namespace: "x-f5xc-"
 
 # =============================================================================
@@ -44,8 +50,41 @@ spec_level:
     type: string
     purpose: Version of enrichment pipeline that processed this spec
     consumers: [pipeline, mcp]
-    example: "2.0.0"
+    example: "3.0.0"
     migrated_from: "x-enriched-version"
+
+  x-f5xc-glossary:
+    type: object
+    purpose: Domain-specific terminology and acronym definitions
+    consumers: [mcp, ide, docs]
+    added_in: "3.0.0"
+
+  x-f5xc-cli-metadata:
+    type: object
+    purpose: CLI-specific metadata for command generation
+    consumers: [cli, mcp]
+    added_in: "3.0.0"
+    note: "Migrated from non-prefixed cli_metadata in v3.0.0"
+
+  x-f5xc-discovered-at:
+    type: string
+    format: iso8601
+    purpose: Timestamp when endpoint was discovered via live API
+    consumers: [discovery]
+    added_in: "3.0.0"
+
+  x-f5xc-api-url:
+    type: string
+    format: uri
+    purpose: API URL used during discovery
+    consumers: [discovery]
+    added_in: "3.0.0"
+
+  x-f5xc-response-time-ms:
+    type: number
+    purpose: Response time in milliseconds during discovery
+    consumers: [discovery]
+    added_in: "3.0.0"
 
 # =============================================================================
 # SCHEMA-LEVEL EXTENSIONS (component schemas)
@@ -339,13 +378,13 @@ preserved_native:
     - x-ves-required
 
 # =============================================================================
-# WRAPPER FIELDS (NOT EXTENSIONS)
+# WRAPPER FIELDS (NOT EXTENSIONS) - DEPRECATED IN v3.0.0
 # =============================================================================
 wrapper_fields:
   description: |
-    These fields are structural wrappers, not OpenAPI extensions.
-    They intentionally do not use x-f5xc-* prefix.
-    The contents within these wrappers DO use x-f5xc-* namespace.
+    In v3.0.0, all wrapper fields have been migrated to the x-f5xc-* namespace.
+    The cli_metadata wrapper field is now x-f5xc-cli-metadata.
 
-  fields:
-    - cli_metadata
+    This section is retained for historical reference only.
+
+  fields: []  # All migrated to x-f5xc-* namespace in v3.0.0

--- a/scripts/discovery/report_generator.py
+++ b/scripts/discovery/report_generator.py
@@ -18,6 +18,11 @@ from .schema_inferrer import InferredSchema
 
 # Add utils to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent / "utils"))
+from extension_constants import (
+    X_F5XC_API_URL,
+    X_F5XC_DISCOVERED_AT,
+    X_F5XC_RESPONSE_TIME_MS,
+)
 from path_config import PathConfig
 from report_base import BaseReporter
 from server_variables_markdown import ServerVariablesMarkdownHelper
@@ -152,8 +157,8 @@ class ReportGenerator(BaseReporter):
                 "title": "F5 Distributed Cloud API (Discovered)",
                 "version": datetime.now(timezone.utc).strftime("%Y%m%d%H%M"),
                 "description": "API specification discovered from live API exploration",
-                "x-discovered-at": session.started_at.isoformat(),
-                "x-api-url": session.api_url,
+                X_F5XC_DISCOVERED_AT: session.started_at.isoformat(),
+                X_F5XC_API_URL: session.api_url,
             },
             "servers": [{"url": session.api_url}] if session.api_url else [],
             "paths": {},
@@ -189,7 +194,7 @@ class ReportGenerator(BaseReporter):
                     ]["example"] = endpoint.examples[0]
 
                 if endpoint.response_time_ms:
-                    operation["x-response-time-ms"] = round(endpoint.response_time_ms, 2)
+                    operation[X_F5XC_RESPONSE_TIME_MS] = round(endpoint.response_time_ms, 2)
 
                 spec["paths"][path][method] = operation
 

--- a/scripts/generate_descriptions.py
+++ b/scripts/generate_descriptions.py
@@ -328,7 +328,7 @@ def get_domain_context(domain: str) -> dict[str, Any]:
         "domain_title": domain.replace("_", " ").title(),
         "use_cases": metadata.get("use_cases", []),
         "related_domains": metadata.get("related_domains", []),
-        "domain_category": metadata.get("domain_category", "Other"),
+        "category": metadata.get("category", "Other"),
         "paths": unique_paths,
         "schemas": unique_schemas,
         "spec_count": len(source_specs),
@@ -349,7 +349,7 @@ def build_prompt(domain: str, context: dict[str, Any]) -> str:
     domain_variants = domain.replace("_", " ")
 
     # Get successful pattern based on domain category
-    category = context.get("domain_category", "Other")
+    category = context.get("category", "Other")
     pattern_key = CATEGORY_TO_PATTERN.get(category, "infrastructure")
     pattern = SUCCESSFUL_PATTERNS.get(pattern_key, SUCCESSFUL_PATTERNS["infrastructure"])
 
@@ -369,7 +369,7 @@ LONG ({len(pattern["long"])} chars): "{pattern["long"]}"
 
 CONTEXT:
 Domain: {domain}
-Category: {context.get("domain_category", "Other")}
+Category: {context.get("category", "Other")}
 Related: {", ".join(context.get("related_domains", []))}
 Specs: {context.get("spec_count", 0)} source specifications
 

--- a/scripts/merge_specs.py
+++ b/scripts/merge_specs.py
@@ -26,13 +26,13 @@ from scripts.utils.domain_metadata import (
     calculate_complexity,
     get_domain_icon,
     get_metadata,
-    get_primary_resources,
     get_primary_resources_metadata,
 )
 from scripts.utils.extension_constants import (
     X_F5XC_ALIASES,
     X_F5XC_CATEGORY,
     X_F5XC_CLI_DOMAIN,
+    X_F5XC_CLI_METADATA,
     X_F5XC_COMPLEXITY,
     X_F5XC_CRITICAL_RESOURCES,
     X_F5XC_DESCRIPTION_MEDIUM,
@@ -42,7 +42,6 @@ from scripts.utils.extension_constants import (
     X_F5XC_IS_PREVIEW,
     X_F5XC_LOGO_SVG,
     X_F5XC_PRIMARY_RESOURCES,
-    X_F5XC_PRIMARY_RESOURCES_SIMPLE,
     X_F5XC_RELATED_DOMAINS,
     X_F5XC_REQUIRES_TIER,
     X_F5XC_UPSTREAM_ETAG,
@@ -239,7 +238,7 @@ def merge_paths(target: dict[str, Any], source: dict[str, Any], domain: str = ""
 def add_domain_metadata_to_spec(spec: dict[str, Any], domain: str) -> None:
     """Add domain classification metadata to spec (idempotent).
 
-    Adds x-ves-cli-domain extension to the spec's info section.
+    Adds x-f5xc-cli-domain extension to the spec's info section.
     Preserves existing values if already present (idempotent behavior).
 
     Args:
@@ -251,9 +250,9 @@ def add_domain_metadata_to_spec(spec: dict[str, Any], domain: str) -> None:
 
     info = spec["info"]
 
-    # Idempotent: preserve existing x-ves-cli-domain
-    if "x-ves-cli-domain" not in info:
-        info["x-ves-cli-domain"] = domain
+    # Idempotent: preserve existing x-f5xc-cli-domain
+    if X_F5XC_CLI_DOMAIN not in info:
+        info[X_F5XC_CLI_DOMAIN] = domain
 
 
 def extract_tags(spec: dict[str, Any]) -> list[dict[str, str]]:
@@ -481,8 +480,6 @@ def create_spec_index(
         icon_info = get_domain_icon(domain)
         # Rich metadata format for IDE tooling (Issues #267-270)
         primary_resources_metadata = get_primary_resources_metadata(domain)
-        # Simple format for backward compatibility
-        primary_resources_simple = get_primary_resources(domain)
 
         # Get multi-tier descriptions (short/medium for index, long already in spec)
         domain_title = domain.replace("_", " ").title()
@@ -504,7 +501,7 @@ def create_spec_index(
             X_F5XC_IS_PREVIEW: metadata.get("is_preview", False),
             X_F5XC_REQUIRES_TIER: metadata.get("requires_tier", "Standard"),
             # Single category field for CLI, UI, docs, and Terraform grouping (DRY)
-            X_F5XC_CATEGORY: metadata.get("category", metadata.get("domain_category", "Other")),
+            X_F5XC_CATEGORY: metadata.get("category", "Other"),
             X_F5XC_ALIASES: metadata.get("aliases", []),
             X_F5XC_USE_CASES: metadata.get("use_cases", []),
             X_F5XC_RELATED_DOMAINS: metadata.get("related_domains", []),
@@ -513,8 +510,6 @@ def create_spec_index(
             X_F5XC_LOGO_SVG: icon_info["logo_svg"],
             # Rich resource metadata for IDE tooling (Issues #267-270)
             X_F5XC_PRIMARY_RESOURCES: primary_resources_metadata,
-            # Backward compatible simple format
-            X_F5XC_PRIMARY_RESOURCES_SIMPLE: primary_resources_simple,
         }
 
         # Add spec-level CLI domain metadata if available
@@ -525,7 +520,7 @@ def create_spec_index(
         # Add CLI metadata if available
         cli_metadata = metadata.get("cli_metadata")
         if cli_metadata:
-            spec_entry["cli_metadata"] = cli_metadata
+            spec_entry[X_F5XC_CLI_METADATA] = cli_metadata
 
         index["specifications"].append(spec_entry)
 

--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -91,12 +91,12 @@ from scripts.utils.domain_metadata import (
     calculate_complexity,
     get_domain_icon,
     get_metadata,
-    get_primary_resources,
     get_primary_resources_metadata,
 )
 from scripts.utils.extension_constants import (
     X_F5XC_ALIASES,
     X_F5XC_CATEGORY,
+    X_F5XC_CLI_METADATA,
     X_F5XC_COMPLEXITY,
     X_F5XC_CRITICAL_RESOURCES,
     X_F5XC_DESCRIPTION_MEDIUM,
@@ -105,7 +105,6 @@ from scripts.utils.extension_constants import (
     X_F5XC_IS_PREVIEW,
     X_F5XC_LOGO_SVG,
     X_F5XC_PRIMARY_RESOURCES,
-    X_F5XC_PRIMARY_RESOURCES_SIMPLE,
     X_F5XC_RELATED_DOMAINS,
     X_F5XC_REQUIRES_TIER,
     X_F5XC_USE_CASES,
@@ -1255,8 +1254,6 @@ def create_spec_index(domain_specs: dict[str, dict[str, Any]], version: str) -> 
         icon_info = get_domain_icon(domain)
         # Rich metadata format for IDE tooling (Issues #267-270)
         primary_resources_metadata = get_primary_resources_metadata(domain)
-        # Simple format for backward compatibility
-        primary_resources_simple = get_primary_resources(domain)
 
         # Build spec entry with x-f5xc-* namespace (Issue #292)
         spec_entry = {
@@ -1273,7 +1270,7 @@ def create_spec_index(domain_specs: dict[str, dict[str, Any]], version: str) -> 
             X_F5XC_IS_PREVIEW: metadata.get("is_preview", False),
             X_F5XC_REQUIRES_TIER: metadata.get("requires_tier", "Standard"),
             # Single category field for CLI, UI, docs, and Terraform grouping (DRY)
-            X_F5XC_CATEGORY: metadata.get("category", metadata.get("domain_category", "Other")),
+            X_F5XC_CATEGORY: metadata.get("category", "Other"),
             X_F5XC_ALIASES: metadata.get("aliases", []),
             X_F5XC_USE_CASES: metadata.get("use_cases", []),
             X_F5XC_RELATED_DOMAINS: metadata.get("related_domains", []),
@@ -1282,14 +1279,12 @@ def create_spec_index(domain_specs: dict[str, dict[str, Any]], version: str) -> 
             X_F5XC_LOGO_SVG: icon_info["logo_svg"],
             # Rich resource metadata for IDE tooling (Issues #267-270)
             X_F5XC_PRIMARY_RESOURCES: primary_resources_metadata,
-            # Backward compatible simple format
-            X_F5XC_PRIMARY_RESOURCES_SIMPLE: primary_resources_simple,
         }
 
         # Add CLI metadata if available
         cli_metadata = metadata.get("cli_metadata")
         if cli_metadata:
-            spec_entry["cli_metadata"] = cli_metadata
+            spec_entry[X_F5XC_CLI_METADATA] = cli_metadata
 
         index["specifications"].append(spec_entry)
 

--- a/scripts/utils/__init__.py
+++ b/scripts/utils/__init__.py
@@ -12,7 +12,7 @@ from .description_enricher import DescriptionEnricher
 from .description_structure import DescriptionStructureTransformer
 from .description_validator import DescriptionValidator
 from .discovery_enricher import DiscoveryEnricher
-from .domain_categorizer import DOMAIN_PATTERNS, DomainCategorizer, categorize_spec
+from .domain_categorizer import DomainCategorizer, categorize_spec
 from .external_docs_enricher import ExternalDocsEnricher
 from .field_description_enricher import FieldDescriptionEnricher
 from .field_metadata_enricher import FieldMetadataEnricher
@@ -26,7 +26,6 @@ from .tag_generator import TagGenerator
 from .validation_enricher import ValidationEnricher
 
 __all__ = [
-    "DOMAIN_PATTERNS",
     "AcronymNormalizer",
     "AliasValidationStats",
     "AliasValidator",

--- a/scripts/utils/branding.py
+++ b/scripts/utils/branding.py
@@ -8,6 +8,8 @@ Fully automated - no manual intervention required.
 Branding Strategy:
   - XCKS (XC Kubernetes Service) = AppStack/VoltStack (comparable to AWS EKS, Azure AKS, GCP GKE)
   - XCCS (XC Container Services) = Virtual Kubernetes (comparable to AWS ECS, Azure Container Services)
+
+Version: v3.0.0 - Uses x-f5xc-* namespace constants
 """
 
 import re
@@ -16,6 +18,8 @@ from pathlib import Path
 from typing import Any, ClassVar
 
 import yaml
+
+from scripts.utils.extension_constants import X_F5XC_GLOSSARY
 
 
 @dataclass
@@ -627,7 +631,7 @@ class BrandingNormalizer:
             return spec
 
         # Check if glossary already exists
-        existing_glossary = spec["info"].get("x-ves-glossary", {})
+        existing_glossary = spec["info"].get(X_F5XC_GLOSSARY, {})
 
         # Merge our glossary terms
         for term, definition in self.glossary.items():
@@ -636,7 +640,7 @@ class BrandingNormalizer:
                 self.stats.glossary_terms_added += 1
 
         if existing_glossary:
-            spec["info"]["x-ves-glossary"] = existing_glossary
+            spec["info"][X_F5XC_GLOSSARY] = existing_glossary
 
         return spec
 

--- a/scripts/utils/deprecated_tier_enricher.py
+++ b/scripts/utils/deprecated_tier_enricher.py
@@ -12,6 +12,8 @@ F5 XC subscription tiers:
 Transformations applied:
 - BASIC → STANDARD (legacy tier replaced)
 - PREMIUM → ADVANCED (legacy tier replaced)
+
+Version: v3.0.0 - Uses x-f5xc-* namespace constants
 """
 
 import logging
@@ -21,6 +23,8 @@ from pathlib import Path
 from typing import Any, ClassVar
 
 import yaml
+
+from scripts.utils.extension_constants import X_F5XC_MINIMUM_CONFIGURATION
 
 logger = logging.getLogger(__name__)
 
@@ -160,7 +164,7 @@ class DeprecatedTierEnricher:
             if self._matches_tier_pattern(schema_name):
                 self._clean_tier_schema(schema_name, schema_def)
 
-            # Also fix CLI examples in any schema with x-ves-minimum-configuration
+            # Also fix CLI examples in any schema with x-f5xc-minimum-configuration
             self._fix_cli_examples(schema_def)
 
         return spec
@@ -262,7 +266,7 @@ class DeprecatedTierEnricher:
         Args:
             schema: Schema definition dictionary
         """
-        min_config = schema.get("x-ves-minimum-configuration", {})
+        min_config = schema.get(X_F5XC_MINIMUM_CONFIGURATION, {})
         if not min_config:
             return
 

--- a/scripts/utils/description_structure.py
+++ b/scripts/utils/description_structure.py
@@ -3,6 +3,8 @@
 
 Extracts embedded metadata (examples, validation rules) to proper fields
 and normalizes whitespace artifacts in description text.
+
+Version: v3.0.0 - Uses x-f5xc-* namespace constants
 """
 
 import re
@@ -11,11 +13,13 @@ from typing import Any
 
 import yaml
 
+from scripts.utils.extension_constants import X_F5XC_EXAMPLE
+
 
 class DescriptionStructureTransformer:
     """Transforms description fields by extracting embedded metadata.
 
-    Extracts Example: sections to x-ves-example field.
+    Extracts Example: sections to x-f5xc-example field.
     Extracts Validation Rules: sections to x-validation-rules extension.
     Extracts X-required markers to x-required extension field.
     Normalizes leading whitespace artifacts.
@@ -119,8 +123,8 @@ class DescriptionStructureTransformer:
                     # Only extract examples/validation/required from 'description' field
                     # Other target fields just get whitespace normalization
                     if key == "description":
-                        # Get existing x-ves-example if present
-                        existing_example = obj.get("x-ves-example")
+                        # Get existing x-f5xc-example if present
+                        existing_example = obj.get(X_F5XC_EXAMPLE)
 
                         # Transform the description (extract metadata)
                         new_value, extracted_example, extracted_validation, extracted_required = (
@@ -138,8 +142,8 @@ class DescriptionStructureTransformer:
                     result[key] = self._transform_recursive(value, target_fields)
 
             # Add extracted fields to this object level
-            if extracted_example and "x-ves-example" not in result:
-                result["x-ves-example"] = extracted_example
+            if extracted_example and X_F5XC_EXAMPLE not in result:
+                result[X_F5XC_EXAMPLE] = extracted_example
 
             if extracted_validation:
                 result["x-validation-rules"] = extracted_validation
@@ -161,7 +165,7 @@ class DescriptionStructureTransformer:
 
         Args:
             description: Original description text.
-            existing_example: Existing x-ves-example value if any.
+            existing_example: Existing x-f5xc-example value if any.
 
         Returns:
             Tuple of (cleaned description, extracted example, extracted validation rules, is_required).
@@ -218,7 +222,7 @@ class DescriptionStructureTransformer:
         description: str,
         existing_example: str | None,
     ) -> tuple[str, str | None]:
-        """Extract Example: section to x-ves-example field."""
+        """Extract Example: section to x-f5xc-example field."""
         result = description
         extracted_value = existing_example
 

--- a/scripts/utils/domain_categorizer.py
+++ b/scripts/utils/domain_categorizer.py
@@ -136,12 +136,7 @@ def get_domain_patterns() -> dict[str, list[str]]:
     return _categorizer.get_domain_patterns()
 
 
-# Backward compatibility export: DOMAIN_PATTERNS dictionary
-DOMAIN_PATTERNS = get_domain_patterns()
-
-
 __all__ = [
-    "DOMAIN_PATTERNS",
     "DomainCategorizer",
     "categorize_spec",
     "get_domain_patterns",

--- a/scripts/utils/domain_metadata.py
+++ b/scripts/utils/domain_metadata.py
@@ -337,8 +337,7 @@ DOMAIN_METADATA = {
     "customer_edge": {
         "is_preview": False,
         "requires_tier": "Standard",
-        "domain_category": "Infrastructure",
-        "ui_category": "Sites",
+        "category": "Infrastructure",
         "aliases": ["ce", "edge", "node"],
         "use_cases": [
             "Configure customer edge nodes",
@@ -351,8 +350,7 @@ DOMAIN_METADATA = {
     "cloud_infrastructure": {
         "is_preview": False,
         "requires_tier": "Standard",
-        "domain_category": "Infrastructure",
-        "ui_category": "Cloud Connect",
+        "category": "Infrastructure",
         "aliases": ["cloud", "infra", "provider"],
         "use_cases": [
             "Connect to cloud providers (AWS, Azure, GCP)",
@@ -365,8 +363,7 @@ DOMAIN_METADATA = {
     "container_services": {
         "is_preview": False,
         "requires_tier": "Advanced",
-        "domain_category": "Infrastructure",
-        "ui_category": "Edge Stack",
+        "category": "Infrastructure",
         "aliases": ["vk8s", "containers", "workloads"],
         # Industry-standard naming (XCCS = XC Container Services)
         "short_name": "XCCS",
@@ -384,8 +381,7 @@ DOMAIN_METADATA = {
     "managed_kubernetes": {
         "is_preview": False,
         "requires_tier": "Advanced",
-        "domain_category": "Infrastructure",
-        "ui_category": "Kubernetes",
+        "category": "Infrastructure",
         "aliases": ["mk8s", "appstack", "k8s-mgmt"],
         # Industry-standard naming (XCKS = XC Kubernetes Service)
         "short_name": "XCKS",
@@ -403,8 +399,7 @@ DOMAIN_METADATA = {
     "service_mesh": {
         "is_preview": False,
         "requires_tier": "Advanced",
-        "domain_category": "Infrastructure",
-        "ui_category": "Service Mesh",
+        "category": "Infrastructure",
         "aliases": ["mesh", "svc-mesh"],
         "use_cases": [
             "Configure service mesh connectivity",
@@ -417,8 +412,7 @@ DOMAIN_METADATA = {
     "sites": {
         "is_preview": False,
         "requires_tier": "Standard",
-        "domain_category": "Infrastructure",
-        "ui_category": "Sites",
+        "category": "Infrastructure",
         "aliases": ["site", "deployment"],
         # Customer Edge deployments: Cloud sites, XCKS (Managed Kubernetes), Mesh
         "deployment_types": ["Cloud Sites", "XCKS (Managed Kubernetes)", "Secure Mesh"],
@@ -436,8 +430,7 @@ DOMAIN_METADATA = {
     "api": {
         "is_preview": False,
         "requires_tier": "Advanced",
-        "domain_category": "Security",
-        "ui_category": "API Protection",
+        "category": "Security",
         "aliases": ["apisec", "api-discovery"],
         "use_cases": [
             "Discover and catalog APIs",
@@ -450,8 +443,7 @@ DOMAIN_METADATA = {
     "waf": {
         "is_preview": False,
         "requires_tier": "Advanced",
-        "domain_category": "Security",
-        "ui_category": "Security",
+        "category": "Security",
         "aliases": ["firewall", "appfw"],
         "use_cases": [
             "Configure web application firewall rules",
@@ -464,7 +456,7 @@ DOMAIN_METADATA = {
     "bot_defense": {
         "is_preview": False,
         "requires_tier": "Advanced",
-        "domain_category": "Security",
+        "category": "Security",
         "aliases": ["bot", "antibot", "botdef"],
         "use_cases": [
             "Manage bot allowlists and defense policies",
@@ -477,8 +469,7 @@ DOMAIN_METADATA = {
     "network_security": {
         "is_preview": False,
         "requires_tier": "Advanced",
-        "domain_category": "Security",
-        "ui_category": "Security",
+        "category": "Security",
         "aliases": ["netsec", "nfw"],
         "use_cases": [
             "Configure network firewall and ACL policies",
@@ -493,8 +484,7 @@ DOMAIN_METADATA = {
     "blindfold": {
         "is_preview": False,
         "requires_tier": "Advanced",
-        "domain_category": "Security",
-        "ui_category": "Security",
+        "category": "Security",
         "aliases": ["bf", "encrypt", "secrets"],
         "use_cases": [
             "Configure secret policies for encryption",
@@ -506,7 +496,7 @@ DOMAIN_METADATA = {
     "client_side_defense": {
         "is_preview": False,
         "requires_tier": "Advanced",
-        "domain_category": "Security",
+        "category": "Security",
         "aliases": ["csd", "client-defense"],
         "use_cases": [
             "Protect user data in transit",
@@ -519,8 +509,7 @@ DOMAIN_METADATA = {
     "ddos": {
         "is_preview": False,
         "requires_tier": "Advanced",
-        "domain_category": "Security",
-        "ui_category": "Infrastructure Protection",
+        "category": "Security",
         "aliases": ["dos", "ddos-protect"],
         "use_cases": [
             "Configure DDoS protection policies",
@@ -532,8 +521,7 @@ DOMAIN_METADATA = {
     "dns": {
         "is_preview": False,
         "requires_tier": "Standard",
-        "domain_category": "Networking",
-        "ui_category": "DNS",
+        "category": "Networking",
         "aliases": ["dns-zone", "zones"],
         "use_cases": [
             "Configure DNS load balancing",
@@ -546,8 +534,7 @@ DOMAIN_METADATA = {
     "virtual": {
         "is_preview": False,
         "requires_tier": "Advanced",
-        "domain_category": "Networking",
-        "ui_category": "Load Balancing",
+        "category": "Networking",
         "aliases": ["lb", "loadbalancer", "vhost"],
         "use_cases": [
             "Configure HTTP/TCP/UDP load balancers",
@@ -564,8 +551,7 @@ DOMAIN_METADATA = {
     "network": {
         "is_preview": False,
         "requires_tier": "Advanced",
-        "domain_category": "Networking",
-        "ui_category": "Networking",
+        "category": "Networking",
         "aliases": ["net", "routing", "bgp"],
         "use_cases": [
             "Configure BGP routing and ASN management",
@@ -580,8 +566,7 @@ DOMAIN_METADATA = {
     "cdn": {
         "is_preview": False,
         "requires_tier": "Advanced",
-        "domain_category": "Networking",
-        "ui_category": "Load Balancing",
+        "category": "Networking",
         "aliases": ["cache", "content"],
         "use_cases": [
             "Configure CDN load balancing",
@@ -595,8 +580,7 @@ DOMAIN_METADATA = {
     "observability": {
         "is_preview": False,
         "requires_tier": "Standard",
-        "domain_category": "Operations",
-        "ui_category": "Observability",
+        "category": "Operations",
         "aliases": ["obs", "monitoring", "synth"],
         "use_cases": [
             "Configure synthetic monitoring",
@@ -608,8 +592,7 @@ DOMAIN_METADATA = {
     "statistics": {
         "is_preview": False,
         "requires_tier": "Standard",
-        "domain_category": "Operations",
-        "ui_category": "Observability",
+        "category": "Operations",
         "aliases": ["stats", "metrics", "logs"],
         "use_cases": [
             "Access flow statistics and analytics",
@@ -624,8 +607,7 @@ DOMAIN_METADATA = {
     "support": {
         "is_preview": False,
         "requires_tier": "Standard",
-        "domain_category": "Operations",
-        "ui_category": "Configuration",
+        "category": "Operations",
         "aliases": ["tickets", "help-desk"],
         "use_cases": [
             "Submit and manage support tickets",
@@ -638,8 +620,7 @@ DOMAIN_METADATA = {
     "authentication": {
         "is_preview": False,
         "requires_tier": "Standard",
-        "domain_category": "Platform",
-        "ui_category": "Identity & Access",
+        "category": "Platform",
         "aliases": ["authn", "oidc", "sso"],
         "use_cases": [
             "Configure authentication mechanisms",
@@ -653,7 +634,7 @@ DOMAIN_METADATA = {
     "system": {
         "is_preview": False,
         "requires_tier": "Standard",
-        "domain_category": "Platform",
+        "category": "Platform",
         "aliases": ["sys", "tenant", "rbac"],
         "use_cases": [
             "Manage tenant configuration",
@@ -667,8 +648,7 @@ DOMAIN_METADATA = {
     "users": {
         "is_preview": False,
         "requires_tier": "Standard",
-        "domain_category": "Platform",
-        "ui_category": "Identity & Access",
+        "category": "Platform",
         "aliases": ["user", "accounts", "iam"],
         "use_cases": [
             "Manage user accounts and tokens",
@@ -682,8 +662,7 @@ DOMAIN_METADATA = {
     "bigip": {
         "is_preview": False,
         "requires_tier": "Advanced",
-        "domain_category": "Platform",
-        "ui_category": "BIG-IP Connector",
+        "category": "Platform",
         "aliases": ["f5-bigip", "irule", "ltm"],
         "use_cases": [
             "Manage BigIP F5 appliances",
@@ -696,8 +675,7 @@ DOMAIN_METADATA = {
     "marketplace": {
         "is_preview": False,
         "requires_tier": "Advanced",
-        "domain_category": "Platform",
-        "ui_category": "Configuration",
+        "category": "Platform",
         "aliases": ["market", "addons", "extensions"],
         "use_cases": [
             "Access third-party integrations and add-ons",
@@ -710,8 +688,7 @@ DOMAIN_METADATA = {
     "nginx_one": {
         "is_preview": False,
         "requires_tier": "Advanced",
-        "domain_category": "Platform",
-        "ui_category": "NGINX One",
+        "category": "Platform",
         "aliases": ["nginx", "nms", "nginx-plus"],
         "use_cases": [
             "Manage NGINX One platform integrations",
@@ -724,8 +701,7 @@ DOMAIN_METADATA = {
     "certificates": {
         "is_preview": False,
         "requires_tier": "Standard",
-        "domain_category": "Security",
-        "ui_category": "Security",
+        "category": "Security",
         "aliases": ["cert", "certs", "ssl", "tls"],
         "use_cases": [
             "Manage SSL/TLS certificates",
@@ -738,8 +714,7 @@ DOMAIN_METADATA = {
     "ai_services": {
         "is_preview": True,
         "requires_tier": "Advanced",
-        "domain_category": "AI",
-        "ui_category": "AI & Automation",
+        "category": "AI",
         "aliases": ["ai", "genai", "assistant"],
         "use_cases": [
             "Access AI-powered features",
@@ -752,8 +727,7 @@ DOMAIN_METADATA = {
     "object_storage": {
         "is_preview": False,
         "requires_tier": "Advanced",
-        "domain_category": "Platform",
-        "ui_category": "Configuration",
+        "category": "Platform",
         "aliases": ["storage", "s3", "buckets"],
         "use_cases": [
             "Manage object storage services",
@@ -765,8 +739,7 @@ DOMAIN_METADATA = {
     "rate_limiting": {
         "is_preview": False,
         "requires_tier": "Advanced",
-        "domain_category": "Networking",
-        "ui_category": "Networking",
+        "category": "Networking",
         "aliases": ["ratelimit", "throttle", "policer"],
         "use_cases": [
             "Configure rate limiter policies",
@@ -778,8 +751,7 @@ DOMAIN_METADATA = {
     "shape": {
         "is_preview": False,
         "requires_tier": "Advanced",
-        "domain_category": "Security",
-        "ui_category": "Client-Side Defense",
+        "category": "Security",
         "aliases": ["shape-sec", "safeap"],
         "use_cases": [
             "Configure Shape Security policies",
@@ -793,7 +765,7 @@ DOMAIN_METADATA = {
     "admin": {
         "is_preview": False,
         "requires_tier": "Standard",
-        "domain_category": "Platform",
+        "category": "Platform",
         "aliases": ["console", "ui"],
         "use_cases": [
             "Configure administration console",
@@ -805,7 +777,7 @@ DOMAIN_METADATA = {
     "billing": {
         "is_preview": False,
         "requires_tier": "Standard",
-        "domain_category": "Platform",
+        "category": "Platform",
         "aliases": ["payment", "subscription", "invoice"],
         "use_cases": [
             "Manage billing and subscription",
@@ -819,7 +791,7 @@ DOMAIN_METADATA = {
     "label": {
         "is_preview": False,
         "requires_tier": "Standard",
-        "domain_category": "Platform",
+        "category": "Platform",
         "aliases": ["labels", "tags", "tagging"],
         "use_cases": [
             "Manage resource labels and tagging",
@@ -831,8 +803,7 @@ DOMAIN_METADATA = {
     "data_intelligence": {
         "is_preview": False,
         "requires_tier": "Standard",
-        "domain_category": "Operations",
-        "ui_category": "Discovery",
+        "category": "Operations",
         "aliases": ["di", "intelligence", "insights"],
         "use_cases": [
             "Analyze security and traffic data",
@@ -844,8 +815,7 @@ DOMAIN_METADATA = {
     "telemetry_and_insights": {
         "is_preview": False,
         "requires_tier": "Standard",
-        "domain_category": "Operations",
-        "ui_category": "Observability",
+        "category": "Operations",
         "aliases": ["telemetry", "ti"],
         "use_cases": [
             "Collect and analyze telemetry data",
@@ -857,8 +827,7 @@ DOMAIN_METADATA = {
     "threat_campaign": {
         "is_preview": False,
         "requires_tier": "Standard",
-        "domain_category": "Security",
-        "ui_category": "Security",
+        "category": "Security",
         "aliases": ["threats", "campaigns", "threat-intel"],
         "use_cases": [
             "Track and analyze threat campaigns",
@@ -870,8 +839,7 @@ DOMAIN_METADATA = {
     "vpm_and_node_management": {
         "is_preview": False,
         "requires_tier": "Standard",
-        "domain_category": "Platform",
-        "ui_category": "Configuration",
+        "category": "Platform",
         "aliases": ["vpm", "nodes", "node-mgmt"],
         "use_cases": [
             "Manage Virtual Private Mesh (VPM) configuration",
@@ -884,8 +852,7 @@ DOMAIN_METADATA = {
     "admin_console_and_ui": {
         "is_preview": False,
         "requires_tier": "Standard",
-        "domain_category": "Platform",
-        "ui_category": "Configuration",
+        "category": "Platform",
         "aliases": ["console-ui", "ui-assets", "static-components"],
         "use_cases": [
             "Manage static UI components for admin console",
@@ -898,8 +865,7 @@ DOMAIN_METADATA = {
     "billing_and_usage": {
         "is_preview": False,
         "requires_tier": "Standard",
-        "domain_category": "Platform",
-        "ui_category": "Configuration",
+        "category": "Platform",
         "aliases": ["billing-usage", "quotas", "usage-tracking"],
         "use_cases": [
             "Manage subscription plans and billing transitions",
@@ -912,8 +878,7 @@ DOMAIN_METADATA = {
     "bot_and_threat_defense": {
         "is_preview": False,
         "requires_tier": "Advanced",
-        "domain_category": "Security",
-        "ui_category": "Bot Defense",
+        "category": "Security",
         "aliases": ["threat-defense", "tpm", "shape-bot"],
         "use_cases": [
             "Configure bot defense instances per namespace",
@@ -926,8 +891,7 @@ DOMAIN_METADATA = {
     "ce_management": {
         "is_preview": False,
         "requires_tier": "Standard",
-        "domain_category": "Infrastructure",
-        "ui_category": "Sites",
+        "category": "Infrastructure",
         "aliases": ["ce-mgmt", "edge-management", "ce-lifecycle"],
         "use_cases": [
             "Manage Customer Edge site lifecycle",
@@ -940,8 +904,7 @@ DOMAIN_METADATA = {
     "data_and_privacy_security": {
         "is_preview": False,
         "requires_tier": "Advanced",
-        "domain_category": "Security",
-        "ui_category": "Data Protection",
+        "category": "Security",
         "aliases": ["data-privacy", "pii", "sensitive-data", "lma"],
         "use_cases": [
             "Configure sensitive data detection policies",
@@ -954,8 +917,7 @@ DOMAIN_METADATA = {
     "secops_and_incident_response": {
         "is_preview": False,
         "requires_tier": "Advanced",
-        "domain_category": "Security",
-        "ui_category": "Security",
+        "category": "Security",
         "aliases": ["secops", "incident-response", "mitigation"],
         "use_cases": [
             "Configure automated threat mitigation policies",
@@ -968,8 +930,7 @@ DOMAIN_METADATA = {
     "tenant_and_identity": {
         "is_preview": False,
         "requires_tier": "Standard",
-        "domain_category": "Platform",
-        "ui_category": "Identity & Access",
+        "category": "Platform",
         "aliases": ["tenant-identity", "idm", "user-settings"],
         "use_cases": [
             "Manage user profiles and notification preferences",
@@ -989,7 +950,7 @@ def get_metadata(domain: str) -> dict[str, Any]:
         domain: The domain name
 
     Returns:
-        Dict with is_preview, requires_tier, domain_category, use_cases, related_domains
+        Dict with is_preview, requires_tier, category, use_cases, related_domains
         and optionally cli_metadata if available for the domain.
         Falls back to defaults if domain not explicitly configured.
     """
@@ -998,7 +959,7 @@ def get_metadata(domain: str) -> dict[str, Any]:
         {
             "is_preview": False,
             "requires_tier": "Standard",
-            "domain_category": "Other",
+            "category": "Other",
         },
     )
 

--- a/scripts/utils/extension_constants.py
+++ b/scripts/utils/extension_constants.py
@@ -3,13 +3,12 @@
 This module provides:
 1. Unified namespace prefix for all enrichment extensions
 2. Field name constants to avoid string duplication
-3. Migration mapping from old field names to new
-4. Validation utilities for extension compliance
+3. Validation utilities for extension compliance
 
 All enrichment code should import field names from this module
 rather than using hardcoded strings.
 
-Issue: #292
+Version: v3.0.0 - Clean break, no backward compatibility
 """
 
 from __future__ import annotations
@@ -25,9 +24,14 @@ X_F5XC_PREFIX = "x-f5xc-"
 # =============================================================================
 
 X_F5XC_CLI_DOMAIN = "x-f5xc-cli-domain"
+X_F5XC_CLI_METADATA = "x-f5xc-cli-metadata"
 X_F5XC_UPSTREAM_TIMESTAMP = "x-f5xc-upstream-timestamp"
 X_F5XC_UPSTREAM_ETAG = "x-f5xc-upstream-etag"
 X_F5XC_ENRICHED_VERSION = "x-f5xc-enriched-version"
+X_F5XC_GLOSSARY = "x-f5xc-glossary"
+X_F5XC_DISCOVERED_AT = "x-f5xc-discovered-at"
+X_F5XC_API_URL = "x-f5xc-api-url"
+X_F5XC_RESPONSE_TIME_MS = "x-f5xc-response-time-ms"
 
 # =============================================================================
 # SCHEMA-LEVEL EXTENSIONS (component schemas)
@@ -71,7 +75,6 @@ X_F5XC_SIDE_EFFECTS = "x-f5xc-side-effects"
 # Single category field for CLI, UI, docs, and Terraform grouping (DRY)
 X_F5XC_CATEGORY = "x-f5xc-category"
 X_F5XC_PRIMARY_RESOURCES = "x-f5xc-primary-resources"
-X_F5XC_PRIMARY_RESOURCES_SIMPLE = "x-f5xc-primary-resources-simple"
 X_F5XC_CRITICAL_RESOURCES = "x-f5xc-critical-resources"
 X_F5XC_DESCRIPTION_SHORT = "x-f5xc-description-short"
 X_F5XC_DESCRIPTION_MEDIUM = "x-f5xc-description-medium"
@@ -104,67 +107,62 @@ PRESERVED_NATIVE_EXTENSIONS = frozenset(
 )
 
 # =============================================================================
-# MIGRATION MAPPING (old field -> new field)
+# VALID EXTENSIONS SET
 # =============================================================================
 
-FIELD_MIGRATION: dict[str, str] = {
-    # Spec-level
-    "x-ves-cli-domain": X_F5XC_CLI_DOMAIN,
-    "x-upstream-timestamp": X_F5XC_UPSTREAM_TIMESTAMP,
-    "x-upstream-etag": X_F5XC_UPSTREAM_ETAG,
-    "x-enriched-version": X_F5XC_ENRICHED_VERSION,
-    # Schema-level
-    "x-ves-cli-aliases": X_F5XC_CLI_ALIASES,
-    "x-ves-minimum-configuration": X_F5XC_MINIMUM_CONFIGURATION,
-    "x-ves-namespace-scope": X_F5XC_NAMESPACE_SCOPE,
-    "x-ves-displayorder": X_F5XC_DISPLAYORDER,
-    # Property-level
-    "x-ves-description": X_F5XC_DESCRIPTION,
-    "x-ves-validation": X_F5XC_VALIDATION,
-    "x-ves-examples": X_F5XC_EXAMPLES,
-    "x-ves-example": X_F5XC_EXAMPLE,
-    "x-ves-completion": X_F5XC_COMPLETION,
-    "x-ves-defaults": X_F5XC_DEFAULTS,
-    "x-ves-required-for-operations": X_F5XC_REQUIRED_FOR_OPERATIONS,
-    "x-ves-required-for": X_F5XC_REQUIRED_FOR,
-    "x-ves-conditions": X_F5XC_CONDITIONS,
-    "x-ves-deprecated": X_F5XC_DEPRECATED,
-    # Operation-level
-    "x-ves-required-fields": X_F5XC_REQUIRED_FIELDS,
-    "x-ves-danger-level": X_F5XC_DANGER_LEVEL,
-    "x-ves-confirmation-required": X_F5XC_CONFIRMATION_REQUIRED,
-    "x-ves-side-effects": X_F5XC_SIDE_EFFECTS,
-    # Index-level (non-prefixed to prefixed)
-    # Single category field replaces both domain_category and ui_category (DRY)
-    "domain_category": X_F5XC_CATEGORY,
-    "ui_category": X_F5XC_CATEGORY,
-    "category": X_F5XC_CATEGORY,
-    "primary_resources": X_F5XC_PRIMARY_RESOURCES,
-    "primary_resources_simple": X_F5XC_PRIMARY_RESOURCES_SIMPLE,
-    "x-ves-critical-resources": X_F5XC_CRITICAL_RESOURCES,
-    "description_short": X_F5XC_DESCRIPTION_SHORT,
-    "description_medium": X_F5XC_DESCRIPTION_MEDIUM,
-    "complexity": X_F5XC_COMPLEXITY,
-    "requires_tier": X_F5XC_REQUIRES_TIER,
-    "is_preview": X_F5XC_IS_PREVIEW,
-    "aliases": X_F5XC_ALIASES,
-    "use_cases": X_F5XC_USE_CASES,
-    "icon": X_F5XC_ICON,
-    "logo_svg": X_F5XC_LOGO_SVG,
-    "related_domains": X_F5XC_RELATED_DOMAINS,
-}
-
-# Reverse mapping for validation
-FIELD_MIGRATION_REVERSE: dict[str, str] = {v: k for k, v in FIELD_MIGRATION.items()}
-
 # All valid x-f5xc-* extension names
-VALID_X_F5XC_EXTENSIONS = frozenset(FIELD_MIGRATION.values()) | {
-    X_F5XC_TERRAFORM_RESOURCE,
-    X_F5XC_DISPLAY_NAME,
-    X_F5XC_DOC_SECTION,
-    X_F5XC_PRIMARY_RESOURCES_SIMPLE,
-    X_F5XC_CRITICAL_RESOURCES,
-}
+VALID_X_F5XC_EXTENSIONS = frozenset(
+    [
+        # Spec-level
+        X_F5XC_CLI_DOMAIN,
+        X_F5XC_CLI_METADATA,
+        X_F5XC_UPSTREAM_TIMESTAMP,
+        X_F5XC_UPSTREAM_ETAG,
+        X_F5XC_ENRICHED_VERSION,
+        X_F5XC_GLOSSARY,
+        X_F5XC_DISCOVERED_AT,
+        X_F5XC_API_URL,
+        X_F5XC_RESPONSE_TIME_MS,
+        # Schema-level
+        X_F5XC_CLI_ALIASES,
+        X_F5XC_MINIMUM_CONFIGURATION,
+        X_F5XC_NAMESPACE_SCOPE,
+        X_F5XC_DISPLAYORDER,
+        X_F5XC_TERRAFORM_RESOURCE,
+        X_F5XC_DISPLAY_NAME,
+        # Property-level
+        X_F5XC_DESCRIPTION,
+        X_F5XC_VALIDATION,
+        X_F5XC_EXAMPLES,
+        X_F5XC_EXAMPLE,
+        X_F5XC_COMPLETION,
+        X_F5XC_DEFAULTS,
+        X_F5XC_REQUIRED_FOR_OPERATIONS,
+        X_F5XC_REQUIRED_FOR,
+        X_F5XC_CONDITIONS,
+        X_F5XC_DEPRECATED,
+        # Operation-level
+        X_F5XC_REQUIRED_FIELDS,
+        X_F5XC_DANGER_LEVEL,
+        X_F5XC_CONFIRMATION_REQUIRED,
+        X_F5XC_SIDE_EFFECTS,
+        # Index-level
+        X_F5XC_CATEGORY,
+        X_F5XC_PRIMARY_RESOURCES,
+        X_F5XC_CRITICAL_RESOURCES,
+        X_F5XC_DESCRIPTION_SHORT,
+        X_F5XC_DESCRIPTION_MEDIUM,
+        X_F5XC_COMPLEXITY,
+        X_F5XC_REQUIRES_TIER,
+        X_F5XC_IS_PREVIEW,
+        X_F5XC_ALIASES,
+        X_F5XC_USE_CASES,
+        X_F5XC_ICON,
+        X_F5XC_LOGO_SVG,
+        X_F5XC_RELATED_DOMAINS,
+        X_F5XC_DOC_SECTION,
+    ],
+)
 
 
 # =============================================================================
@@ -196,37 +194,12 @@ def is_preserved_native(field_name: str) -> bool:
     return field_name in PRESERVED_NATIVE_EXTENSIONS
 
 
-def is_old_extension(field_name: str) -> bool:
-    """Check if a field name is an old extension that needs migration.
-
-    Args:
-        field_name: The field name to check
-
-    Returns:
-        True if the field should be migrated to x-f5xc-* namespace
-    """
-    return field_name in FIELD_MIGRATION
-
-
-def migrate_field_name(old_name: str) -> str:
-    """Get the new x-f5xc-* field name for an old field.
-
-    Args:
-        old_name: The old field name
-
-    Returns:
-        The new x-f5xc-* field name, or the original if no migration needed
-    """
-    return FIELD_MIGRATION.get(old_name, old_name)
-
-
 def validate_no_invalid_extensions(obj: dict, path: str = "") -> list[str]:
     """Validate that an object contains no invalid custom extensions.
 
-    Checks that all custom fields (x-* or non-standard) are either:
+    Checks that all custom fields (x-*) are either:
     - Valid x-f5xc-* extensions
     - Preserved F5 native extensions
-    - Standard OpenAPI fields
 
     Args:
         obj: Dictionary to validate
@@ -237,88 +210,13 @@ def validate_no_invalid_extensions(obj: dict, path: str = "") -> list[str]:
     """
     errors: list[str] = []
 
-    # Standard OpenAPI fields that are allowed
-    standard_fields = {
-        "openapi",
-        "info",
-        "servers",
-        "paths",
-        "components",
-        "security",
-        "tags",
-        "externalDocs",
-        "title",
-        "description",
-        "version",
-        "termsOfService",
-        "contact",
-        "license",
-        "name",
-        "url",
-        "email",
-        "schemas",
-        "responses",
-        "parameters",
-        "examples",
-        "requestBodies",
-        "headers",
-        "securitySchemes",
-        "links",
-        "callbacks",
-        "type",
-        "properties",
-        "items",
-        "required",
-        "enum",
-        "default",
-        "format",
-        "minimum",
-        "maximum",
-        "minLength",
-        "maxLength",
-        "pattern",
-        "additionalProperties",
-        "allOf",
-        "anyOf",
-        "oneOf",
-        "not",
-        "$ref",
-        "nullable",
-        "readOnly",
-        "writeOnly",
-        "deprecated",
-        "example",
-        "summary",
-        "operationId",
-        "requestBody",
-        "in",
-        "schema",
-        "content",
-        "variables",
-    }
-
     for key, value in obj.items():
         current_path = f"{path}.{key}" if path else key
 
-        # Check if this is a custom field
-        if key.startswith("x-"):
-            # Must be either x-f5xc-* or preserved native
-            if not (is_valid_extension(key) or is_preserved_native(key)):
-                # Check if it's an old field that should have been migrated
-                if is_old_extension(key):
-                    new_name = migrate_field_name(key)
-                    errors.append(
-                        f"{current_path}: Old extension '{key}' should be migrated to '{new_name}'",
-                    )
-                else:
-                    errors.append(
-                        f"{current_path}: Invalid extension '{key}' (not in x-f5xc-* namespace)",
-                    )
-        elif key not in standard_fields and not key.startswith("$") and is_old_extension(key):
-            # Non-standard field without x- prefix in index.json context
-            new_name = migrate_field_name(key)
+        # Check if this is a custom extension field that violates namespace rules
+        if key.startswith("x-") and not (is_valid_extension(key) or is_preserved_native(key)):
             errors.append(
-                f"{current_path}: Non-standard field '{key}' should be migrated to '{new_name}'",
+                f"{current_path}: Invalid extension '{key}' (must use x-f5xc-* namespace)",
             )
 
         # Recursively check nested objects

--- a/scripts/utils/field_description_enricher.py
+++ b/scripts/utils/field_description_enricher.py
@@ -5,6 +5,8 @@ using pattern-based matching with high-confidence patterns only.
 
 Follows conservative approach: only matches patterns with 95%+ confidence.
 Respects existing descriptions and examples (never overwrites).
+
+Version: v3.0.0 - Uses x-f5xc-* namespace constants
 """
 
 import re
@@ -13,6 +15,8 @@ from pathlib import Path
 from typing import Any
 
 import yaml
+
+from scripts.utils.extension_constants import X_F5XC_EXAMPLE
 
 
 @dataclass
@@ -288,7 +292,7 @@ class FieldDescriptionEnricher:
                 self.stats.descriptions_added += 1
 
         # Never overwrite existing examples if preserve_existing is True
-        if self.preserve_existing and ("example" in prop or "x-ves-example" in prop):
+        if self.preserve_existing and ("example" in prop or X_F5XC_EXAMPLE in prop):
             # Example already exists, skip
             pass
         else:
@@ -297,7 +301,7 @@ class FieldDescriptionEnricher:
             if example is not None:
                 # Convert to string to ensure JSON schema compatibility
                 # Examples may be numbers (8080) or booleans that need string representation
-                prop["x-ves-example"] = str(example) if not isinstance(example, str) else example
+                prop[X_F5XC_EXAMPLE] = str(example) if not isinstance(example, str) else example
                 self.stats.examples_added += 1
 
     def _find_description(self, prop_name: str) -> str | None:

--- a/scripts/utils/namespace_scope_enricher.py
+++ b/scripts/utils/namespace_scope_enricher.py
@@ -10,7 +10,7 @@ Adds the x-f5xc-namespace-scope extension with values:
 
 Configuration is loaded from config/namespace_scope.yaml.
 
-Issue: #292 - Migrated from x-ves-* to x-f5xc-* namespace
+Version: v3.0.0 - Uses x-f5xc-* namespace constants
 """
 
 import logging
@@ -106,7 +106,7 @@ class NamespaceScopeEnricher:
     def enrich_spec(self, spec: dict[str, Any]) -> dict[str, Any]:
         """Enrich OpenAPI specification with namespace scope metadata.
 
-        Adds x-ves-namespace-scope to the spec's info section based on
+        Adds x-f5xc-namespace-scope to the spec's info section based on
         the resource type detected from the spec title or paths.
 
         Args:
@@ -166,7 +166,7 @@ class NamespaceScopeEnricher:
         Uses multiple strategies to determine the resource type:
         1. Extract from spec title (e.g., "Alert Policy API" -> "alert_policy")
         2. Extract from first path (e.g., "/api/.../alert_policy/..." -> "alert_policy")
-        3. Extract from x-ves-cli-domain or other extensions
+        3. Extract from x-f5xc-cli-domain or other extensions
 
         Args:
             spec: OpenAPI specification

--- a/scripts/utils/validation_enricher.py
+++ b/scripts/utils/validation_enricher.py
@@ -6,6 +6,8 @@ to schema properties based on field types and names.
 Conservative approach: only applies well-established validation rules.
 Respects existing constraints (never overwrites).
 Merges with discovery constraints when available.
+
+Version: v3.0.0 - Uses x-f5xc-* namespace constants
 """
 
 import re
@@ -14,6 +16,8 @@ from pathlib import Path
 from typing import Any
 
 import yaml
+
+from scripts.utils.extension_constants import X_F5XC_VALIDATION
 
 
 @dataclass
@@ -318,13 +322,13 @@ class ValidationEnricher:
     def _merge_discovery_constraints(self, prop: dict[str, Any], _prop_name: str) -> None:
         """Merge constraints from discovery data if available.
 
-        Discovery constraints are stored in x-ves-validation-rules extension.
+        Discovery constraints are stored in x-f5xc-validation extension.
 
         Args:
             prop: Property definition to update
             _prop_name: Name of the property (unused, kept for interface compatibility)
         """
-        discovery_rules = prop.get("x-ves-validation-rules", {})
+        discovery_rules = prop.get(X_F5XC_VALIDATION, {})
         if not discovery_rules:
             return
 

--- a/tests/test_branding_normalizer.py
+++ b/tests/test_branding_normalizer.py
@@ -248,8 +248,8 @@ class TestGlossaryIntegration:
         result = normalizer.normalize_spec(spec)
 
         # Check that glossary was added
-        assert "x-ves-glossary" in result["info"]
-        glossary = result["info"]["x-ves-glossary"]
+        assert "x-f5xc-glossary" in result["info"]
+        glossary = result["info"]["x-f5xc-glossary"]
         assert "XCKS" in glossary or "XCCS" in glossary
 
     def test_glossary_terms_added_stat(self) -> None:
@@ -269,7 +269,7 @@ class TestGlossaryIntegration:
         spec = {
             "info": {
                 "title": "Test API",
-                "x-ves-glossary": {
+                "x-f5xc-glossary": {
                     "CUSTOM_TERM": {"term": "Custom", "definition": "Custom def"},
                 },
             },
@@ -278,7 +278,7 @@ class TestGlossaryIntegration:
         result = normalizer.normalize_spec(spec)
 
         # Custom term should be preserved
-        glossary = result["info"]["x-ves-glossary"]
+        glossary = result["info"]["x-f5xc-glossary"]
         assert "CUSTOM_TERM" in glossary
         assert glossary["CUSTOM_TERM"]["definition"] == "Custom def"
 

--- a/tests/test_deprecated_tier_enricher.py
+++ b/tests/test_deprecated_tier_enricher.py
@@ -64,7 +64,7 @@ def spec_with_cli_examples():
             "schemas": {
                 "TestSchema": {
                     "type": "object",
-                    "x-ves-minimum-configuration": {
+                    "x-f5xc-minimum-configuration": {
                         "example_curl": 'curl -X POST "$F5XC_API_URL/api/subscription_basic_tier" -d @test.json',
                     },
                 },
@@ -224,7 +224,7 @@ class TestCLIExampleTransformation:
     def test_cli_example_basic_to_standard(self, enricher, spec_with_cli_examples):
         """Test CLI examples are updated from basic to standard."""
         result = enricher.enrich(spec_with_cli_examples)
-        example_cmd = result["components"]["schemas"]["TestSchema"]["x-ves-minimum-configuration"][
+        example_cmd = result["components"]["schemas"]["TestSchema"]["x-f5xc-minimum-configuration"][
             "example_curl"
         ]
 
@@ -245,7 +245,7 @@ class TestCLIExampleTransformation:
                 "schemas": {
                     "TestSchema": {
                         "type": "object",
-                        "x-ves-minimum-configuration": {
+                        "x-f5xc-minimum-configuration": {
                             "example_curl": 'curl -X POST "$F5XC_API_URL/api/subscription_premium_tier" -d @test.json',
                         },
                     },
@@ -254,7 +254,7 @@ class TestCLIExampleTransformation:
         }
 
         result = enricher.enrich(spec)
-        example_cmd = result["components"]["schemas"]["TestSchema"]["x-ves-minimum-configuration"][
+        example_cmd = result["components"]["schemas"]["TestSchema"]["x-f5xc-minimum-configuration"][
             "example_curl"
         ]
 

--- a/tests/test_domain_categorizer.py
+++ b/tests/test_domain_categorizer.py
@@ -9,7 +9,6 @@ import re
 import pytest
 
 from scripts.utils.domain_categorizer import (
-    DOMAIN_PATTERNS,
     DomainCategorizer,
     categorize_spec,
     get_domain_patterns,
@@ -268,21 +267,24 @@ class TestFallbackBehavior:
         assert categorize_spec("Ves.Io.Schema.Views.App_Firewall.Json") == "waf"
 
 
-class TestBackwardCompatibility:
-    """Test backward compatibility exports."""
+class TestModuleLevelFunctions:
+    """Test module-level function exports (v3.0.0 - no backward compat exports)."""
 
-    def test_domain_patterns_export(self) -> None:
-        """Verify that DOMAIN_PATTERNS dictionary is exported."""
-        assert isinstance(DOMAIN_PATTERNS, dict)
-        assert len(DOMAIN_PATTERNS) == 34  # 34 domains in current structure
-        assert "sites" in DOMAIN_PATTERNS
-        assert isinstance(DOMAIN_PATTERNS["sites"], list)
+    def test_categorize_spec_function(self) -> None:
+        """Verify that categorize_spec function works correctly."""
+        assert categorize_spec("ves.io.schema.views.aws_vpc_site.json") == "sites"
+
+    def test_get_domain_patterns_function(self) -> None:
+        """Verify that get_domain_patterns function works correctly."""
+        patterns = get_domain_patterns()
+        assert isinstance(patterns, dict)
+        assert len(patterns) == 34  # 34 domains in current structure
 
     def test_all_domains_in_patterns(self) -> None:
-        """Verify that all domains are present in DOMAIN_PATTERNS."""
-        # Actual 34 domains from current structure
+        """Verify that all domains are present via get_domain_patterns()."""
+        patterns = get_domain_patterns()
         expected_domain_count = 34
-        assert len(DOMAIN_PATTERNS) == expected_domain_count
+        assert len(patterns) == expected_domain_count
 
         # Verify key domains exist
         key_domains = {
@@ -300,17 +302,7 @@ class TestBackwardCompatibility:
             "admin_console_and_ui",
             "label",
         }
-        assert key_domains.issubset(set(DOMAIN_PATTERNS.keys()))
-
-    def test_module_level_functions(self) -> None:
-        """Verify that module-level functions work correctly."""
-        # Test categorize_spec function
-        assert categorize_spec("ves.io.schema.views.aws_vpc_site.json") == "sites"
-
-        # Test get_domain_patterns function
-        patterns = get_domain_patterns()
-        assert isinstance(patterns, dict)
-        assert len(patterns) == 34  # 34 domains in current structure
+        assert key_domains.issubset(set(patterns.keys()))
 
 
 class TestCaching:
@@ -349,11 +341,12 @@ class TestPatternValidation:
     """Test that domain patterns are valid regexes."""
 
     def test_all_patterns_valid_regex(self) -> None:
-        """Verify that all patterns in DOMAIN_PATTERNS are valid regexes."""
+        """Verify that all patterns via get_domain_patterns() are valid regexes."""
+        domain_patterns = get_domain_patterns()
         # Collect all patterns first to validate outside nested loop
         all_patterns = [
             (domain, pattern)
-            for domain, patterns in DOMAIN_PATTERNS.items()
+            for domain, patterns in domain_patterns.items()
             for pattern in patterns
         ]
 

--- a/tests/test_domain_metadata.py
+++ b/tests/test_domain_metadata.py
@@ -75,7 +75,7 @@ class TestMetadataRetrieval:
     def test_get_metadata_known_domain(self):
         """Test retrieving metadata for known domain."""
         metadata = get_metadata("virtual")
-        assert metadata["domain_category"] == "Networking"
+        assert metadata["category"] == "Networking"
         assert metadata["requires_tier"] == "Advanced"
         assert metadata["is_preview"] is False
         assert len(metadata["use_cases"]) > 0
@@ -86,7 +86,7 @@ class TestMetadataRetrieval:
         metadata = get_metadata("unknown_domain_xyz")
         assert metadata["is_preview"] is False
         assert metadata["requires_tier"] == "Standard"
-        assert metadata["domain_category"] == "Other"
+        assert metadata["category"] == "Other"
 
     def test_get_all_metadata(self):
         """Test retrieving all domain metadata."""
@@ -103,7 +103,7 @@ class TestMetadataRetrieval:
             metadata = get_metadata(domain)
             assert "is_preview" in metadata
             assert "requires_tier" in metadata
-            assert "domain_category" in metadata
+            assert "category" in metadata
             assert "use_cases" in metadata
             assert "related_domains" in metadata
 
@@ -228,7 +228,7 @@ class TestMetadataConsistency:
                 assert isinstance(rel_domain, str)
 
     def test_metadata_categories_valid(self):
-        """Test that domain_category values are valid."""
+        """Test that category values are valid."""
         valid_categories = {
             "Infrastructure",
             "Security",
@@ -239,7 +239,7 @@ class TestMetadataConsistency:
             "Other",
         }
         for metadata in DOMAIN_METADATA.values():
-            category = metadata.get("domain_category", "Other")
+            category = metadata.get("category", "Other")
             assert category in valid_categories
 
     def test_metadata_tiers_valid(self):

--- a/tests/test_extension_naming.py
+++ b/tests/test_extension_naming.py
@@ -1,6 +1,6 @@
 """Tests for extension naming constants and validation utilities.
 
-Issue: #292
+Version: v3.0.0 - Clean break, no backward compatibility
 """
 
 from __future__ import annotations
@@ -8,8 +8,6 @@ from __future__ import annotations
 import pytest
 
 from scripts.utils.extension_constants import (
-    FIELD_MIGRATION,
-    FIELD_MIGRATION_REVERSE,
     PRESERVED_NATIVE_EXTENSIONS,
     VALID_X_F5XC_EXTENSIONS,
     X_F5XC_CATEGORY,
@@ -32,10 +30,8 @@ from scripts.utils.extension_constants import (
     X_F5XC_TERRAFORM_RESOURCE,
     X_F5XC_UPSTREAM_ETAG,
     X_F5XC_UPSTREAM_TIMESTAMP,
-    is_old_extension,
     is_preserved_native,
     is_valid_extension,
-    migrate_field_name,
     validate_no_invalid_extensions,
 )
 
@@ -133,60 +129,6 @@ class TestExtensionConstants:
         assert "_" not in after_prefix, f"Constant '{constant}' should use hyphens, not underscores"
 
 
-class TestFieldMigration:
-    """Tests for field migration mapping."""
-
-    def test_migration_mapping_not_empty(self) -> None:
-        """Migration mapping should have entries."""
-        assert len(FIELD_MIGRATION) > 0
-
-    def test_all_migrations_to_x_f5xc(self) -> None:
-        """All migration targets must use x-f5xc- prefix."""
-        for old, new in FIELD_MIGRATION.items():
-            assert new.startswith(X_F5XC_PREFIX), (
-                f"Migration '{old}' -> '{new}' target missing prefix"
-            )
-
-    def test_reverse_mapping_consistency(self) -> None:
-        """Reverse mapping should map to at least one valid old field.
-
-        Note: Multiple old fields can map to the same new field (DRY principle).
-        For example: domain_category, ui_category, category -> x-f5xc-category
-        """
-        # Reverse mapping has fewer entries due to DRY consolidation
-        assert len(FIELD_MIGRATION_REVERSE) <= len(FIELD_MIGRATION)
-        for new_field in FIELD_MIGRATION_REVERSE:
-            # The reverse should point to one of the old fields that maps to it
-            old_field = FIELD_MIGRATION_REVERSE[new_field]
-            assert FIELD_MIGRATION[old_field] == new_field
-
-    @pytest.mark.parametrize(
-        ("old_field", "expected_new"),
-        [
-            ("x-ves-cli-domain", "x-f5xc-cli-domain"),
-            ("x-ves-minimum-configuration", "x-f5xc-minimum-configuration"),
-            ("x-ves-danger-level", "x-f5xc-danger-level"),
-            # All category fields map to single x-f5xc-category (DRY)
-            ("domain_category", "x-f5xc-category"),
-            ("ui_category", "x-f5xc-category"),
-            ("category", "x-f5xc-category"),
-            ("primary_resources", "x-f5xc-primary-resources"),
-            ("description_short", "x-f5xc-description-short"),
-            ("description_medium", "x-f5xc-description-medium"),
-            ("x-upstream-timestamp", "x-f5xc-upstream-timestamp"),
-            ("x-enriched-version", "x-f5xc-enriched-version"),
-        ],
-    )
-    def test_specific_migrations(self, old_field: str, expected_new: str) -> None:
-        """Test specific field migrations are correct."""
-        assert FIELD_MIGRATION[old_field] == expected_new
-
-    def test_no_self_migrations(self) -> None:
-        """No field should migrate to itself."""
-        for old, new in FIELD_MIGRATION.items():
-            assert old != new, f"Field '{old}' migrates to itself"
-
-
 class TestPreservedNativeExtensions:
     """Tests for preserved F5 native extensions."""
 
@@ -207,11 +149,6 @@ class TestPreservedNativeExtensions:
         """Known F5 native extensions should be in preserved set."""
         assert extension in PRESERVED_NATIVE_EXTENSIONS
 
-    def test_preserved_not_in_migration(self) -> None:
-        """Preserved extensions should not be in migration mapping."""
-        for ext in PRESERVED_NATIVE_EXTENSIONS:
-            assert ext not in FIELD_MIGRATION, f"Preserved extension '{ext}' should not be migrated"
-
 
 class TestValidExtensions:
     """Tests for valid extension set."""
@@ -224,11 +161,6 @@ class TestValidExtensions:
         """All valid extensions must have x-f5xc- prefix."""
         for ext in VALID_X_F5XC_EXTENSIONS:
             assert ext.startswith(X_F5XC_PREFIX), f"Valid extension '{ext}' missing prefix"
-
-    def test_migration_targets_are_valid(self) -> None:
-        """All migration targets should be valid extensions."""
-        for new in FIELD_MIGRATION.values():
-            assert new in VALID_X_F5XC_EXTENSIONS, f"Migration target '{new}' not in valid set"
 
     def test_new_fields_are_valid(self) -> None:
         """New fields should be in valid extensions set."""
@@ -262,30 +194,6 @@ class TestValidationFunctions:
         assert not is_preserved_native(X_F5XC_CLI_DOMAIN)
         assert not is_preserved_native("x-ves-cli-domain")
 
-    def test_is_old_extension_true(self) -> None:
-        """Old extensions should return True."""
-        assert is_old_extension("x-ves-cli-domain")
-        assert is_old_extension("domain_category")
-        assert is_old_extension("x-upstream-timestamp")
-
-    def test_is_old_extension_false(self) -> None:
-        """New extensions should return False."""
-        assert not is_old_extension(X_F5XC_CLI_DOMAIN)
-        assert not is_old_extension("x-random-field")
-
-    def test_migrate_field_name_old(self) -> None:
-        """Old field names should be migrated."""
-        assert migrate_field_name("x-ves-cli-domain") == X_F5XC_CLI_DOMAIN
-        # Both old category fields map to the single X_F5XC_CATEGORY (DRY)
-        assert migrate_field_name("domain_category") == X_F5XC_CATEGORY
-        assert migrate_field_name("ui_category") == X_F5XC_CATEGORY
-        assert migrate_field_name("category") == X_F5XC_CATEGORY
-
-    def test_migrate_field_name_unknown(self) -> None:
-        """Unknown fields should return unchanged."""
-        assert migrate_field_name("unknown-field") == "unknown-field"
-        assert migrate_field_name(X_F5XC_CLI_DOMAIN) == X_F5XC_CLI_DOMAIN
-
 
 class TestValidateNoInvalidExtensions:
     """Tests for the spec validation function."""
@@ -309,23 +217,13 @@ class TestValidateNoInvalidExtensions:
         """Old x-ves-* fields should produce errors."""
         spec = {
             "info": {
-                "x-ves-cli-domain": "test",  # old field
+                "x-ves-cli-domain": "test",  # old field - not in valid or preserved sets
             },
         }
         errors = validate_no_invalid_extensions(spec)
         assert len(errors) == 1
         assert "x-ves-cli-domain" in errors[0]
-        assert "x-f5xc-cli-domain" in errors[0]
-
-    def test_non_prefixed_field_error(self) -> None:
-        """Non-prefixed fields should produce errors."""
-        spec = {
-            "domain_category": "test",  # should be x-f5xc-category (DRY)
-        }
-        errors = validate_no_invalid_extensions(spec)
-        assert len(errors) == 1
-        assert "domain_category" in errors[0]
-        assert "x-f5xc-category" in errors[0]  # Consolidated category field
+        assert "x-f5xc-*" in errors[0]  # Generic namespace guidance
 
     def test_preserved_native_no_error(self) -> None:
         """Preserved native fields should not produce errors."""
@@ -372,51 +270,3 @@ class TestValidateNoInvalidExtensions:
         errors = validate_no_invalid_extensions(spec)
         assert len(errors) == 1
         assert "x-random-vendor-field" in errors[0]
-
-
-class TestMigrationCompleteness:
-    """Tests to ensure migration mapping is complete."""
-
-    def test_all_x_ves_cli_fields_migrated(self) -> None:
-        """All known x-ves-cli-* fields should have migration."""
-        expected_x_ves_cli = ["x-ves-cli-domain", "x-ves-cli-aliases"]
-        for field in expected_x_ves_cli:
-            assert field in FIELD_MIGRATION, f"Missing migration for '{field}'"
-
-    def test_all_index_fields_migrated(self) -> None:
-        """All known index.json non-prefixed fields should have migration."""
-        expected_index = [
-            "domain_category",
-            "ui_category",
-            "primary_resources",
-            "description_short",
-            "description_medium",
-            "complexity",
-            "requires_tier",
-            "is_preview",
-            "aliases",
-            "use_cases",
-            "icon",
-            "logo_svg",
-            "related_domains",
-        ]
-        for field in expected_index:
-            assert field in FIELD_MIGRATION, f"Missing migration for index field '{field}'"
-
-    def test_intentional_dry_consolidation(self) -> None:
-        """DRY consolidation: multiple old fields can map to same new field.
-
-        Specifically, domain_category, ui_category, and category all map to
-        x-f5xc-category to avoid redundant fields in the spec.
-        """
-        # All three category fields should map to the same target
-        assert FIELD_MIGRATION["domain_category"] == X_F5XC_CATEGORY
-        assert FIELD_MIGRATION["ui_category"] == X_F5XC_CATEGORY
-        assert FIELD_MIGRATION["category"] == X_F5XC_CATEGORY
-
-        # Verify we have fewer unique targets than source fields (due to consolidation)
-        targets = list(FIELD_MIGRATION.values())
-        unique_targets = set(targets)
-        assert len(unique_targets) < len(targets), (
-            "Expected DRY consolidation (fewer targets than sources)"
-        )

--- a/tests/test_field_description_enricher.py
+++ b/tests/test_field_description_enricher.py
@@ -161,7 +161,7 @@ class TestPropertyEnrichment:
 
         assert "description" in prop
         assert prop["description"] == "Human-readable name for the resource"
-        assert "x-ves-example" in prop
+        assert "x-f5xc-example" in prop
 
     def test_property_preserves_existing_description(self, enricher):
         """Test that existing descriptions are preserved."""
@@ -180,7 +180,7 @@ class TestPropertyEnrichment:
 
         # Example should remain unchanged
         assert prop["example"] == original_example
-        assert "x-ves-example" not in prop
+        assert "x-f5xc-example" not in prop
 
     def test_stats_incremented_on_enrichment(self, enricher):
         """Test that stats are updated during enrichment."""
@@ -207,15 +207,15 @@ class TestSpecEnrichment:
         # Check that name field was enriched
         user_props = result["components"]["schemas"]["User"]["properties"]
         assert "description" in user_props["name"]
-        assert "x-ves-example" in user_props["name"]
+        assert "x-f5xc-example" in user_props["name"]
 
         # Check that email field was enriched
         assert "description" in user_props["email"]
-        assert "x-ves-example" in user_props["email"]
+        assert "x-f5xc-example" in user_props["email"]
 
         # Check that unmatched id field wasn't enriched
         assert "description" not in user_props["id"]
-        assert "x-ves-example" not in user_props["id"]
+        assert "x-f5xc-example" not in user_props["id"]
 
     def test_stats_after_full_enrichment(self, enricher, simple_spec):
         """Test that stats are correctly updated after full enrichment."""
@@ -374,34 +374,34 @@ class TestEdgeCases:
 
 
 class TestExampleStringConversion:
-    """Test x-ves-example string type conversion (Issue #136 fix)."""
+    """Test x-f5xc-example string type conversion (Issue #136 fix)."""
 
     def test_example_is_always_string_type_for_numeric(self, enricher):
-        """Verify x-ves-example is string even for numeric values (port: 8080)."""
+        """Verify x-f5xc-example is string even for numeric values (port: 8080)."""
         prop = {"type": "integer"}
         enricher._enrich_property(prop, "port", "TestSchema")
 
-        assert "x-ves-example" in prop
-        assert isinstance(prop["x-ves-example"], str), "x-ves-example must be string type"
-        assert prop["x-ves-example"] == "8080"
+        assert "x-f5xc-example" in prop
+        assert isinstance(prop["x-f5xc-example"], str), "x-f5xc-example must be string type"
+        assert prop["x-f5xc-example"] == "8080"
 
     def test_example_is_always_string_type_for_boolean(self, enricher):
-        """Verify x-ves-example is string for boolean values."""
+        """Verify x-f5xc-example is string for boolean values."""
         prop = {"type": "boolean"}
         enricher._enrich_property(prop, "enabled", "TestSchema")
 
         # Note: boolean fields don't currently have examples in default config
         # but this test ensures if they did, they'd be strings
-        if "x-ves-example" in prop:
-            assert isinstance(prop["x-ves-example"], str), "x-ves-example must be string type"
+        if "x-f5xc-example" in prop:
+            assert isinstance(prop["x-f5xc-example"], str), "x-f5xc-example must be string type"
 
     def test_example_is_always_string_type_for_uuid(self, enricher):
-        """Verify x-ves-example is string for UUID values."""
+        """Verify x-f5xc-example is string for UUID values."""
         prop = {"type": "string", "format": "uuid"}
         enricher._enrich_property(prop, "uuid", "TestSchema")
 
-        assert "x-ves-example" in prop
-        assert isinstance(prop["x-ves-example"], str), "x-ves-example must be string type"
+        assert "x-f5xc-example" in prop
+        assert isinstance(prop["x-f5xc-example"], str), "x-f5xc-example must be string type"
 
 
 class TestResourceTypeInference:

--- a/tests/test_validation_enricher.py
+++ b/tests/test_validation_enricher.py
@@ -296,7 +296,7 @@ class TestDiscoveryConstraintMerging:
         """Test that discovery constraints are merged."""
         prop = {
             "type": "string",
-            "x-ves-validation-rules": {
+            "x-f5xc-validation": {
                 "pattern": "^[A-Z]+$",
                 "maxLength": 50,
             },
@@ -313,7 +313,7 @@ class TestDiscoveryConstraintMerging:
         prop = {
             "type": "string",
             "minLength": 10,
-            "x-ves-validation-rules": {
+            "x-f5xc-validation": {
                 "minLength": 5,
             },
         }


### PR DESCRIPTION
## Summary

Major version v3.0.0 refactor that removes ALL backward compatibility code and fully implements the x-f5xc-* namespace. This is a breaking change release.

## Changes

### Core Namespace Migration
- **extension_constants.py**: Removed FIELD_MIGRATION dictionary, migrate_field_name(), is_old_extension() functions
- **domain_metadata.py**: Renamed `domain_category` → `category`, removed `ui_category` (DRY consolidation)
- **domain_categorizer.py**: Removed DOMAIN_PATTERNS backward compat export

### Field Migrations
| Old Field | New Field |
|-----------|-----------|
| `cli_metadata` | `x-f5xc-cli-metadata` |
| `x-ves-glossary` | `x-f5xc-glossary` |
| `x-ves-example` | `x-f5xc-example` |
| `x-ves-minimum-configuration` | `x-f5xc-minimum-configuration` |
| `x-ves-validation-rules` | `x-f5xc-validation` |
| `domain_category` | `category` |

### New Extensions Added
- `x-f5xc-discovered-at` - Discovery timestamp
- `x-f5xc-api-url` - API URL during discovery
- `x-f5xc-response-time-ms` - Response time metrics

### Files Changed (23 files, -250 lines)
- Core scripts: 8 files
- Enrichers: 6 files
- Config: 1 file (extension_registry.yaml v3.0.0)
- Documentation: 1 file (CLAUDE.md)
- Tests: 7 files

## Breaking Changes

1. All `x-ves-*` enrichment fields now use `x-f5xc-*` namespace
2. Removed FIELD_MIGRATION backward compatibility
3. Removed primary_resources_simple from index.json
4. Removed DOMAIN_PATTERNS module-level export
5. domain_category/ui_category consolidated to single `category` field

## Preserved (Not Changed)

F5 native extensions remain unchanged:
- `x-ves-proto-*`, `x-displayname`, `x-ves-oneof`, `x-ves-default`, `x-ves-required`

## Testing

All 891 tests pass.

Closes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)