### PR TITLE
feat: add x-f5xc-description-short extension for Terraform documentation

### DIFF
--- a/config/property_description_short.yaml
+++ b/config/property_description_short.yaml
@@ -1,0 +1,171 @@
+# Property Short Description Configuration
+# Issue #330: Add x-f5xc-description-short for Terraform documentation
+#
+# Generates concise 80-150 char descriptions for schema properties
+# with long descriptions (>300 chars) following Azure/AWS conventions.
+
+version: "1.0.0"
+
+# Generation settings
+settings:
+  # Only process descriptions longer than this (chars)
+  min_source_length: 300
+
+  # Target length range for generated descriptions
+  target_min_length: 80
+  target_max_length: 150
+
+  # Never overwrite existing x-f5xc-description-short
+  preserve_existing: true
+
+# Manual overrides for high-priority fields
+# Format: "schemaName.propertyName": "Short description"
+overrides:
+  # Virtual domain - load balancing
+  "schemavirtual_hostCreateSpecType.domains": "List of domain names matched to this virtual host."
+  "schemavirtual_hostCreateSpecType.routes": "HTTP routing rules for matching requests to backends."
+  "schemavirtual_hostCreateSpecType.default_route_pools": "Default origin pools for unmatched requests."
+  "schemavirtual_hostCreateSpecType.advertise_on_public": "Advertise virtual host on F5 XC public network."
+  "schemavirtual_hostCreateSpecType.http": "HTTP protocol configuration including port and TLS settings."
+  "schemavirtual_hostCreateSpecType.https": "HTTPS protocol configuration with TLS certificate handling."
+
+  # Virtual domain - security
+  "schemavirtual_hostCreateSpecType.waf_type": "Web Application Firewall protection mode for this virtual host."
+  "schemavirtual_hostCreateSpecType.cors_policy": "Cross-Origin Resource Sharing policy for browser requests."
+  "schemavirtual_hostCreateSpecType.csrf_policy": "Cross-Site Request Forgery protection configuration."
+  "schemavirtual_hostCreateSpecType.js_challenge": "JavaScript browser challenge for bot detection."
+
+  # Cluster and endpoint management
+  "clusterCreateSpecType.endpoint_subsets": "Endpoint groups based on metadata labels for traffic routing."
+  "clusterCreateSpecType.endpoints": "List of endpoints for this cluster."
+  "clusterCreateSpecType.health_checks": "Health check configuration for backend monitoring."
+
+  # Retry and circuit breaker
+  "schemaRetryPolicyType.retry_condition": "Conditions that trigger request retry (5xx, connection failures)."
+  "schemaRetryPolicyType.num_retries": "Maximum number of retry attempts. Default: 1."
+  "schemaCircuitBreakerType.consecutive_5xx": "Consecutive 5xx errors before circuit opens."
+
+  # WAF domain
+  "schemawaf_ruleCreateSpecType.rule_id": "Unique identifier for this WAF rule."
+  "schemawaf_ruleCreateSpecType.mode": "WAF rule mode: block, detect, or disable."
+  "schemaapp_firewallCreateSpecType.blocking_page": "Custom HTML page for blocked requests."
+
+  # DNS domain
+  "schemadns_zoneCreateSpecType.domain": "DNS domain name for this zone."
+  "schemadns_zoneCreateSpecType.primary": "Primary DNS server configuration."
+  "schemadns_recordCreateSpecType.type": "DNS record type (A, AAAA, CNAME, MX, TXT, etc.)."
+  "schemadns_recordCreateSpecType.ttl": "Time-to-live in seconds. Default: 300."
+
+  # CDN domain
+  "schemacdn_loadbalancerCreateSpecType.origin": "Origin server configuration for CDN."
+  "schemacdn_loadbalancerCreateSpecType.cache_options": "Cache behavior and TTL settings."
+  "schemacdn_loadbalancerCreateSpecType.domains": "Domain names for CDN distribution."
+
+  # Sites domain
+  "schemasiteCreateSpecType.site_type": "Site deployment type (AWS, Azure, GCP, VMware, etc.)."
+  "schemasiteCreateSpecType.coordinates": "Geographic coordinates for site location."
+  "schemasiteCreateSpecType.address": "Physical address of the site location."
+
+  # Common fields across domains
+  "protobufAny.type_url": "URL identifying the protocol buffer message type."
+
+# Pattern-based templates
+# These match property names across all schemas
+patterns:
+  # Domain and hostname patterns
+  - pattern: '\.domains$'
+    template: "List of domain names for this resource. Supports wildcards."
+
+  - pattern: '\.fqdn$'
+    template: "Fully qualified domain name for this resource."
+
+  - pattern: '\.hostname$'
+    template: "Hostname for this resource."
+
+  # Timeout patterns
+  - pattern: '\.timeout$'
+    template: "Timeout duration. Specify with unit (e.g., '30s', '5m')."
+
+  - pattern: '\.idle_timeout$'
+    template: "Idle connection timeout duration."
+
+  - pattern: '\.connect_timeout$'
+    template: "Connection establishment timeout duration."
+
+  # Health check patterns
+  - pattern: '\.health_check'
+    template: "Health check configuration for backend monitoring."
+
+  - pattern: '\.healthcheck'
+    template: "Health check configuration for backend monitoring."
+
+  # Retry patterns
+  - pattern: '\.retry_'
+    template: "Retry policy configuration for failed requests."
+
+  - pattern: '\.num_retries$'
+    template: "Maximum number of retry attempts."
+
+  # Port patterns
+  - pattern: '\.port$'
+    template: "Network port number. Range: 1-65535."
+
+  - pattern: '\.target_port$'
+    template: "Target port for backend connections."
+
+  # TLS/SSL patterns
+  - pattern: '\.tls_'
+    template: "TLS/SSL configuration settings."
+
+  - pattern: '\.certificate'
+    template: "TLS certificate configuration."
+
+  # Endpoint patterns
+  - pattern: '\.endpoints$'
+    template: "List of endpoint addresses for this resource."
+
+  - pattern: '\.endpoint_subsets$'
+    template: "Endpoint groups based on metadata labels."
+
+  # Route patterns
+  - pattern: '\.routes$'
+    template: "Routing rules for request matching and forwarding."
+
+  - pattern: '\.default_route'
+    template: "Default route for requests not matching other rules."
+
+  # Pool patterns
+  - pattern: '\.origin_pool'
+    template: "Backend origin server pool configuration."
+
+  - pattern: '\.pool$'
+    template: "Backend server pool configuration."
+
+  # Policy patterns
+  - pattern: '_policy$'
+    template: "Policy configuration for this feature."
+
+  - pattern: '\.waf_'
+    template: "Web Application Firewall configuration."
+
+  # Selector patterns
+  - pattern: '\.selector$'
+    template: "Label selector for resource matching."
+
+  - pattern: '\.namespace_selector$'
+    template: "Namespace selector for cross-namespace references."
+
+# Exclusions - never generate short descriptions for these
+# Uses regex patterns matching "schemaName.propertyName"
+exclusions:
+  # Protocol buffer internal fields
+  - "^protobufAny\\.value$"
+
+  # Validation rule fields (metadata, not user-facing)
+  - ".*_validation_rules$"
+
+  # Internal reference fields
+  - ".*\\.\\$ref$"
+
+  # Empty or placeholder schemas
+  - "^schemaEmpty\\."

--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -83,6 +83,7 @@ from scripts.utils import (
     GuidedWorkflowEnricher,
     MinimumConfigurationEnricher,
     OperationMetadataEnricher,
+    PropertyDescriptionShortEnricher,
     ReadOnlyEnricher,
     ResourceExamplesEnricher,
     SchemaFixer,
@@ -290,12 +291,18 @@ def enrich_spec(spec: dict[str, Any], config: dict) -> tuple[dict[str, Any], dic
     spec = field_description_enricher.enrich_spec(spec)
     field_desc_stats = field_description_enricher.get_stats()
 
-    # 12. Field-level validation rule enrichment (add min/max, patterns, formats)
+    # 12. Property short description enrichment (Issue #330)
+    # Generate 80-150 char descriptions for properties with long descriptions (>300 chars)
+    prop_desc_short_enricher = PropertyDescriptionShortEnricher()
+    spec = prop_desc_short_enricher.enrich_spec(spec)
+    prop_desc_short_stats = prop_desc_short_enricher.get_stats()
+
+    # 13. Field-level validation rule enrichment (add min/max, patterns, formats)
     validation_enricher = ValidationEnricher()
     spec = validation_enricher.enrich_spec(spec)
     validation_stats = validation_enricher.get_stats()
 
-    # 13. Operation metadata enrichment (add danger levels, required fields, side effects)
+    # 14. Operation metadata enrichment (add danger levels, required fields, side effects)
     operation_metadata_enricher = OperationMetadataEnricher()
     spec = operation_metadata_enricher.enrich_spec(spec)
     op_stats = operation_metadata_enricher.get_stats()
@@ -327,6 +334,15 @@ def enrich_spec(spec: dict[str, Any], config: dict) -> tuple[dict[str, Any], dic
         "domains_normalized": domain_normalize_count,
         "field_descriptions_added": field_desc_stats.get("descriptions_added", 0),
         "field_examples_added": field_desc_stats.get("examples_added", 0),
+        "short_descriptions_added": prop_desc_short_stats.get("short_descriptions_added", 0),
+        "short_descriptions_from_extraction": prop_desc_short_stats.get(
+            "descriptions_from_extraction",
+            0,
+        ),
+        "short_descriptions_from_config": prop_desc_short_stats.get(
+            "descriptions_from_config",
+            0,
+        ),
         "validation_rules_added": validation_stats.get("patterns_added", 0),
         "validation_constraints_added": validation_stats.get("constraints_added", 0),
         "operations_enriched": op_stats.get("operations_enriched", 0),

--- a/scripts/utils/__init__.py
+++ b/scripts/utils/__init__.py
@@ -23,6 +23,7 @@ from .guided_workflow_enricher import GuidedWorkflowEnricher
 from .minimum_configuration_enricher import MinimumConfigurationEnricher
 from .namespace_scope_enricher import NamespaceScopeEnricher
 from .operation_metadata_enricher import OperationMetadataEnricher
+from .property_description_short_enricher import PropertyDescriptionShortEnricher
 from .readonly_enricher import ReadOnlyEnricher
 from .resource_examples_enricher import ResourceExamplesEnricher
 from .schema_fixer import SchemaFixer
@@ -56,6 +57,7 @@ __all__ = [
     "MinimumConfigurationEnricher",
     "NamespaceScopeEnricher",
     "OperationMetadataEnricher",
+    "PropertyDescriptionShortEnricher",
     "ReadOnlyEnricher",
     "ResourceExamplesEnricher",
     "SchemaFixer",

--- a/scripts/utils/property_description_short_enricher.py
+++ b/scripts/utils/property_description_short_enricher.py
@@ -1,0 +1,522 @@
+"""Property Short Description Enricher for OpenAPI specifications.
+
+Generates concise 80-150 character descriptions for schema properties
+with long descriptions (>300 chars) to support Terraform provider documentation.
+
+Follows Azure/AWS Terraform provider conventions:
+- Imperative tone: "Specifies...", "Enables...", "Configures..."
+- Single sentence, no code examples
+- Includes defaults and constraints inline
+
+Issue #330: https://github.com/robinmordasiewicz/f5xc-api-enriched/issues/330
+"""
+
+import re
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, ClassVar
+
+import yaml
+
+from scripts.utils.extension_constants import X_F5XC_DESCRIPTION_SHORT
+
+
+@dataclass
+class PropertyDescriptionShortStats:
+    """Statistics from property short description enrichment."""
+
+    fields_processed: int = 0
+    short_descriptions_added: int = 0
+    descriptions_from_extraction: int = 0
+    descriptions_from_config: int = 0
+    skipped_already_short: int = 0
+    skipped_has_extension: int = 0
+    schemas_processed: int = 0
+
+    def to_dict(self) -> dict[str, int]:
+        """Convert stats to dictionary."""
+        return {
+            "fields_processed": self.fields_processed,
+            "short_descriptions_added": self.short_descriptions_added,
+            "descriptions_from_extraction": self.descriptions_from_extraction,
+            "descriptions_from_config": self.descriptions_from_config,
+            "skipped_already_short": self.skipped_already_short,
+            "skipped_has_extension": self.skipped_has_extension,
+            "schemas_processed": self.schemas_processed,
+        }
+
+
+@dataclass
+class EnricherSettings:
+    """Configuration settings for the enricher."""
+
+    min_source_length: int = 300
+    target_min_length: int = 80
+    target_max_length: int = 150
+    preserve_existing: bool = True
+
+
+@dataclass
+class PatternTemplate:
+    """A pattern-based template for generating short descriptions."""
+
+    pattern: re.Pattern[str]
+    template: str
+
+
+class PropertyDescriptionShortEnricher:
+    """Generate 80-150 char descriptions for properties with long descriptions.
+
+    Uses multi-tier approach:
+    1. Configuration override (highest priority)
+    2. Pattern-based templates
+    3. First sentence extraction with style transformation
+
+    Follows Azure/AWS Terraform provider conventions for documentation.
+    """
+
+    # Style transformation rules (pattern -> replacement)
+    # Replacement can be string or callable for regex substitution
+    STYLE_TRANSFORMS: ClassVar[list[tuple[str, str | Callable[[re.Match[str]], str]]]] = [
+        # Convert passive/descriptive to imperative
+        (r"^The\s+(\w+)\s+(?:is|are)\s+(?:used\s+)?(?:to\s+)?", r"Specifies \1 "),
+        (r"^This\s+(?:field|property|setting)\s+(?:is|specifies|defines|contains)\s+", ""),
+        (r"^This\s+(?:is\s+)?(?:the\s+)?", ""),
+        (r"^A\s+(\w+)\s+that\s+", r"\1 that "),
+        (r"^An?\s+", ""),
+        # Capitalize first letter after transforms
+        (r"^([a-z])", lambda m: m.group(1).upper()),
+    ]
+
+    # Patterns to remove from descriptions
+    # Order matters: code blocks must be removed before inline code
+    REMOVAL_PATTERNS: ClassVar[list[str]] = [
+        r"```[\s\S]*?```",  # Remove code blocks FIRST
+        r"`[^`]+`",  # Remove inline code SECOND
+        r"\s*Example:.*",
+        r"\s*Examples?:.*",
+        r"\s*See\s+http[s]?://\S+",
+        r"\s*For\s+more\s+information.*",
+        r"\s*Note:.*",
+        r"\s*\([^)]*http[s]?://[^)]*\)",
+    ]
+
+    def __init__(self, config_path: Path | None = None) -> None:
+        """Initialize enricher with configuration.
+
+        Args:
+            config_path: Path to property_description_short.yaml config.
+                        Defaults to config/property_description_short.yaml.
+        """
+        if config_path is None:
+            config_path = (
+                Path(__file__).parent.parent.parent / "config" / "property_description_short.yaml"
+            )
+
+        self.config_path = config_path
+        self.settings = EnricherSettings()
+        self.overrides: dict[str, str] = {}
+        self.patterns: list[PatternTemplate] = []
+        self.exclusions: list[re.Pattern[str]] = []
+        self.stats = PropertyDescriptionShortStats()
+        self._config_version: str = "1.0.0"
+
+        self._load_config()
+        self._compile_style_transforms()
+
+    def _load_config(self) -> None:
+        """Load configuration from YAML file."""
+        if not self.config_path.exists():
+            return
+
+        try:
+            with self.config_path.open() as f:
+                config = yaml.safe_load(f) or {}
+
+            self._config_version = config.get("version", "1.0.0")
+
+            # Load settings
+            settings = config.get("settings", {})
+            self.settings = EnricherSettings(
+                min_source_length=settings.get("min_source_length", 300),
+                target_min_length=settings.get("target_min_length", 80),
+                target_max_length=settings.get("target_max_length", 150),
+                preserve_existing=settings.get("preserve_existing", True),
+            )
+
+            # Load overrides
+            self.overrides = config.get("overrides", {})
+
+            # Compile patterns
+            for pattern_config in config.get("patterns", []):
+                try:
+                    compiled = re.compile(pattern_config["pattern"])
+                    self.patterns.append(
+                        PatternTemplate(
+                            pattern=compiled,
+                            template=pattern_config["template"],
+                        ),
+                    )
+                except re.error:  # noqa: PERF203
+                    pass  # Skip invalid patterns
+
+            # Compile exclusions
+            for exclusion in config.get("exclusions", []):
+                try:  # noqa: SIM105
+                    self.exclusions.append(re.compile(exclusion))
+                except re.error:  # noqa: PERF203
+                    pass
+
+        except Exception:  # noqa: S110
+            pass  # Use defaults on any error
+
+    def _compile_style_transforms(self) -> None:
+        """Pre-compile style transformation patterns."""
+        self._compiled_transforms: list[tuple[re.Pattern[str], Any]] = []
+        for pattern, replacement in self.STYLE_TRANSFORMS:
+            try:
+                compiled = re.compile(pattern, re.IGNORECASE)
+                self._compiled_transforms.append((compiled, replacement))
+            except re.error:  # noqa: PERF203
+                pass
+
+        self._compiled_removals: list[re.Pattern[str]] = []
+        for pattern in self.REMOVAL_PATTERNS:
+            try:  # noqa: SIM105
+                self._compiled_removals.append(re.compile(pattern, re.IGNORECASE | re.DOTALL))
+            except re.error:  # noqa: PERF203
+                pass
+
+    def get_config_version(self) -> str:
+        """Get the configuration file version."""
+        return self._config_version
+
+    def get_stats(self) -> dict[str, int]:
+        """Get enrichment statistics."""
+        return self.stats.to_dict()
+
+    def enrich_spec(self, spec: dict[str, Any]) -> dict[str, Any]:
+        """Enrich all schema properties with short descriptions.
+
+        Args:
+            spec: OpenAPI specification dictionary
+
+        Returns:
+            Enriched specification with x-f5xc-description-short on properties
+        """
+        components = spec.get("components", {})
+        schemas = components.get("schemas", {})
+
+        for schema_name, schema in schemas.items():
+            self._process_schema(schema_name, schema)
+
+        return spec
+
+    def _process_schema(self, schema_name: str, schema: dict[str, Any]) -> None:
+        """Process a single schema and its properties.
+
+        Args:
+            schema_name: Name of the schema
+            schema: Schema definition dictionary
+        """
+        self.stats.schemas_processed += 1
+
+        # Process direct properties
+        properties = schema.get("properties", {})
+        for prop_name, prop in properties.items():
+            self._process_property(schema_name, prop_name, prop)
+
+        # Process nested schemas in allOf, oneOf, anyOf
+        for composition_key in ["allOf", "oneOf", "anyOf"]:
+            for item in schema.get(composition_key, []):
+                if isinstance(item, dict):
+                    nested_props = item.get("properties", {})
+                    for prop_name, prop in nested_props.items():
+                        self._process_property(schema_name, prop_name, prop)
+
+        # Process items for array schemas
+        items = schema.get("items", {})
+        if isinstance(items, dict):
+            items_props = items.get("properties", {})
+            for prop_name, prop in items_props.items():
+                self._process_property(schema_name, prop_name, prop)
+
+    def _process_property(
+        self,
+        schema_name: str,
+        prop_name: str,
+        prop: dict[str, Any],
+    ) -> None:
+        """Process a single property for short description enrichment.
+
+        Args:
+            schema_name: Name of the parent schema
+            prop_name: Name of the property
+            prop: Property definition dictionary
+        """
+        self.stats.fields_processed += 1
+
+        # Skip if property is not a dict
+        if not isinstance(prop, dict):
+            return
+
+        description = prop.get("description", "")
+
+        # Skip if no description or not longer than minimum source length
+        if not description or len(description) <= self.settings.min_source_length:
+            self.stats.skipped_already_short += 1
+            return
+
+        # Skip if already has short description and preserve_existing is True
+        if self.settings.preserve_existing and X_F5XC_DESCRIPTION_SHORT in prop:
+            self.stats.skipped_has_extension += 1
+            return
+
+        # Check exclusions
+        full_path = f"{schema_name}.{prop_name}"
+        for exclusion in self.exclusions:
+            if exclusion.match(full_path):
+                return
+
+        # Generate short description
+        short_desc = self._generate_short_description(schema_name, prop_name, description)
+
+        if short_desc:
+            prop[X_F5XC_DESCRIPTION_SHORT] = short_desc
+            self.stats.short_descriptions_added += 1
+
+    def _generate_short_description(
+        self,
+        schema_name: str,
+        prop_name: str,
+        description: str,
+    ) -> str | None:
+        """Generate a short description for a property.
+
+        Uses priority order:
+        1. Configuration override
+        2. Pattern-based template
+        3. First sentence extraction
+
+        Args:
+            schema_name: Name of the parent schema
+            prop_name: Name of the property
+            description: Original long description
+
+        Returns:
+            Short description (80-150 chars) or None if generation failed
+        """
+        full_path = f"{schema_name}.{prop_name}"
+
+        # 1. Check for configuration override
+        if full_path in self.overrides:
+            self.stats.descriptions_from_config += 1
+            return self.overrides[full_path]
+
+        # 2. Check pattern-based templates
+        for pattern_template in self.patterns:
+            if pattern_template.pattern.search(prop_name):
+                self.stats.descriptions_from_config += 1
+                return pattern_template.template
+
+        # 3. Extract and transform from description
+        short_desc = self._extract_and_transform(description)
+        if short_desc:
+            self.stats.descriptions_from_extraction += 1
+            return short_desc
+
+        return None
+
+    def _extract_and_transform(self, description: str) -> str | None:
+        """Extract first sentence and apply style transformations.
+
+        Args:
+            description: Original long description
+
+        Returns:
+            Transformed short description or None
+        """
+        # Clean the description first
+        cleaned = self._clean_description(description)
+
+        # Extract first sentence
+        first_sentence = self._extract_first_sentence(cleaned)
+        if not first_sentence:
+            return None
+
+        # Apply style transformations
+        transformed = self._apply_style_rules(first_sentence)
+
+        # Validate length
+        if len(transformed) < self.settings.target_min_length:
+            # Try to expand with second sentence if too short
+            second = self._extract_second_sentence(cleaned)
+            if second:
+                combined = f"{transformed} {second}"
+                if len(combined) <= self.settings.target_max_length:
+                    transformed = combined
+
+        # Truncate if too long
+        if len(transformed) > self.settings.target_max_length:
+            transformed = self._smart_truncate(transformed, self.settings.target_max_length)
+
+        # Final validation
+        if self.settings.target_min_length <= len(transformed) <= self.settings.target_max_length:
+            return transformed
+
+        # If still too short, return what we have (some description is better than none)
+        if transformed and len(transformed) >= 40:
+            return transformed
+
+        return None
+
+    def _clean_description(self, description: str) -> str:
+        """Remove code examples, HTTP details, and normalize whitespace.
+
+        Args:
+            description: Original description
+
+        Returns:
+            Cleaned description
+        """
+        cleaned = description
+
+        # Apply removal patterns
+        for pattern in self._compiled_removals:
+            cleaned = pattern.sub("", cleaned)
+
+        # Normalize whitespace
+        cleaned = re.sub(r"\s+", " ", cleaned).strip()
+
+        return cleaned  # noqa: RET504
+
+    def _extract_first_sentence(self, text: str) -> str | None:
+        """Extract the first sentence from text.
+
+        Args:
+            text: Input text
+
+        Returns:
+            First sentence or None
+        """
+        if not text:
+            return None
+
+        # Split on sentence boundaries
+        # Match period, exclamation, or question mark followed by space and capital
+        # or end of string
+        sentences = re.split(r"(?<=[.!?])\s+(?=[A-Z])|(?<=[.!?])$", text)
+
+        if sentences:
+            first = sentences[0].strip()
+            # Ensure it ends with punctuation
+            if first and first[-1] not in ".!?":
+                first += "."
+            return first
+
+        return text.strip()
+
+    def _extract_second_sentence(self, text: str) -> str | None:
+        """Extract the second sentence from text.
+
+        Args:
+            text: Input text
+
+        Returns:
+            Second sentence or None
+        """
+        sentences = re.split(r"(?<=[.!?])\s+(?=[A-Z])", text)
+        if len(sentences) >= 2:
+            return sentences[1].strip()
+        return None
+
+    def _apply_style_rules(self, text: str) -> str:
+        """Apply Azure/AWS style transformations.
+
+        Converts to imperative tone and cleans up phrasing.
+
+        Args:
+            text: Input text
+
+        Returns:
+            Transformed text
+        """
+        result = text
+
+        for pattern, replacement in self._compiled_transforms:
+            if callable(replacement):
+                result = pattern.sub(replacement, result)
+            else:
+                result = pattern.sub(replacement, result)
+
+        # Ensure first character is capitalized
+        if result and result[0].islower():
+            result = result[0].upper() + result[1:]
+
+        # Clean up any double spaces
+        result = re.sub(r"\s+", " ", result).strip()
+
+        return result  # noqa: RET504
+
+    def _smart_truncate(self, text: str, max_length: int) -> str:
+        """Truncate text at word boundary with ellipsis if needed.
+
+        Args:
+            text: Text to truncate
+            max_length: Maximum length including any ellipsis
+
+        Returns:
+            Truncated text
+        """
+        if len(text) <= max_length:
+            return text
+
+        # Try to truncate at word boundary
+        truncated = text[: max_length - 3]
+        last_space = truncated.rfind(" ")
+
+        if last_space > max_length // 2:
+            truncated = truncated[:last_space]
+
+        # Remove trailing punctuation before adding ellipsis
+        truncated = truncated.rstrip(".,;:-")
+
+        return truncated + "..."
+
+    def get_override(self, schema_name: str, prop_name: str) -> str | None:
+        """Get configured override for a property.
+
+        Args:
+            schema_name: Schema name
+            prop_name: Property name
+
+        Returns:
+            Override value or None
+        """
+        full_path = f"{schema_name}.{prop_name}"
+        return self.overrides.get(full_path)
+
+    def has_override(self, schema_name: str, prop_name: str) -> bool:
+        """Check if property has a configured override.
+
+        Args:
+            schema_name: Schema name
+            prop_name: Property name
+
+        Returns:
+            True if override exists
+        """
+        return self.get_override(schema_name, prop_name) is not None
+
+
+# Module-level singleton for convenient access
+_enricher_instance: PropertyDescriptionShortEnricher | None = None
+
+
+def get_property_description_short_enricher() -> PropertyDescriptionShortEnricher:
+    """Get or create the singleton enricher instance."""
+    global _enricher_instance  # noqa: PLW0603
+    if _enricher_instance is None:
+        _enricher_instance = PropertyDescriptionShortEnricher()
+    return _enricher_instance

--- a/tests/test_property_description_short_enricher.py
+++ b/tests/test_property_description_short_enricher.py
@@ -1,0 +1,653 @@
+"""Unit tests for PropertyDescriptionShortEnricher.
+
+Tests for Issue #330: Add x-f5xc-description-short extensions for Terraform documentation.
+Generates concise 80-150 character descriptions for schema properties with long descriptions.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+from scripts.utils.extension_constants import X_F5XC_DESCRIPTION_SHORT
+from scripts.utils.property_description_short_enricher import (
+    EnricherSettings,
+    PatternTemplate,
+    PropertyDescriptionShortEnricher,
+    PropertyDescriptionShortStats,
+)
+
+
+@pytest.fixture
+def enricher():
+    """Create enricher with default config."""
+    return PropertyDescriptionShortEnricher()
+
+
+@pytest.fixture
+def long_description():
+    """Create a description >300 chars for testing."""
+    return (
+        "The javascript challenge type specifies the type of JavaScript challenge "
+        "to use for bot detection. When enabled, clients must execute JavaScript code "
+        "to prove they are real browsers. This is useful for filtering out automated "
+        "traffic. Example configuration: { type: 'js_challenge', timeout: 300 }. "
+        "For more information, see https://docs.example.com/js-challenge."
+    )
+
+
+@pytest.fixture
+def short_description():
+    """Create a description <300 chars (should not be processed)."""
+    return "A short description that should not trigger short description generation."
+
+
+@pytest.fixture
+def spec_with_long_descriptions(long_description):
+    """Create a spec with properties that have long descriptions."""
+    return {
+        "components": {
+            "schemas": {
+                "TestSchema": {
+                    "type": "object",
+                    "properties": {
+                        "js_challenge": {
+                            "type": "object",
+                            "description": long_description,
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "Short description under 300 chars.",
+                        },
+                    },
+                },
+            },
+        },
+    }
+
+
+class TestPropertyDescriptionShortStats:
+    """Test stats dataclass functionality."""
+
+    def test_stats_initialization(self):
+        """Test stats initialize to zero."""
+        stats = PropertyDescriptionShortStats()
+        assert stats.fields_processed == 0
+        assert stats.short_descriptions_added == 0
+        assert stats.descriptions_from_extraction == 0
+        assert stats.descriptions_from_config == 0
+        assert stats.skipped_already_short == 0
+        assert stats.skipped_has_extension == 0
+        assert stats.schemas_processed == 0
+
+    def test_stats_to_dict(self):
+        """Test stats to_dict conversion."""
+        stats = PropertyDescriptionShortStats(
+            fields_processed=10,
+            short_descriptions_added=5,
+            descriptions_from_extraction=3,
+            descriptions_from_config=2,
+        )
+        result = stats.to_dict()
+
+        assert result["fields_processed"] == 10
+        assert result["short_descriptions_added"] == 5
+        assert result["descriptions_from_extraction"] == 3
+        assert result["descriptions_from_config"] == 2
+
+
+class TestEnricherSettings:
+    """Test settings dataclass."""
+
+    def test_default_settings(self):
+        """Test default settings values."""
+        settings = EnricherSettings()
+        assert settings.min_source_length == 300
+        assert settings.target_min_length == 80
+        assert settings.target_max_length == 150
+        assert settings.preserve_existing is True
+
+    def test_custom_settings(self):
+        """Test custom settings values."""
+        settings = EnricherSettings(
+            min_source_length=200,
+            target_min_length=50,
+            target_max_length=100,
+            preserve_existing=False,
+        )
+        assert settings.min_source_length == 200
+        assert settings.target_min_length == 50
+        assert settings.target_max_length == 100
+        assert settings.preserve_existing is False
+
+
+class TestEnricherBasics:
+    """Test basic enricher functionality."""
+
+    def test_initialization(self):
+        """Test enricher initializes with default config."""
+        enricher = PropertyDescriptionShortEnricher()
+        assert enricher.settings.min_source_length == 300
+        assert enricher.settings.target_min_length == 80
+        assert enricher.settings.target_max_length == 150
+        assert enricher.settings.preserve_existing is True
+
+    def test_config_loading_missing_file(self):
+        """Test enricher uses defaults when config file missing."""
+        enricher = PropertyDescriptionShortEnricher(
+            config_path=Path("/nonexistent/path.yaml"),
+        )
+        assert enricher.settings.min_source_length == 300
+        assert enricher.settings.preserve_existing is True
+
+    def test_stats_initialization(self):
+        """Test enrichment stats start at zero."""
+        enricher = PropertyDescriptionShortEnricher()
+        stats = enricher.get_stats()
+        assert stats["fields_processed"] == 0
+        assert stats["short_descriptions_added"] == 0
+        assert stats["schemas_processed"] == 0
+
+    def test_config_version(self):
+        """Test config version is accessible."""
+        enricher = PropertyDescriptionShortEnricher()
+        version = enricher.get_config_version()
+        assert version is not None
+        assert isinstance(version, str)
+
+
+class TestFirstSentenceExtraction:
+    """Test first sentence extraction logic."""
+
+    def test_extract_first_sentence_simple(self, enricher):
+        """Test extracting first sentence from simple text."""
+        text = "This is the first sentence. This is the second sentence."
+        result = enricher._extract_first_sentence(text)  # noqa: SLF001
+        assert result == "This is the first sentence."
+
+    def test_extract_first_sentence_no_period(self, enricher):
+        """Test handling text without period."""
+        text = "This is a sentence without a period at the end"
+        result = enricher._extract_first_sentence(text)  # noqa: SLF001
+        assert result.endswith(".")
+
+    def test_extract_first_sentence_exclamation(self, enricher):
+        """Test extracting sentence ending with exclamation."""
+        text = "Warning! This is important. More text here."
+        result = enricher._extract_first_sentence(text)  # noqa: SLF001
+        assert result == "Warning!"
+
+    def test_extract_first_sentence_question(self, enricher):
+        """Test extracting sentence ending with question mark."""
+        text = "What is this? This explains it."
+        result = enricher._extract_first_sentence(text)  # noqa: SLF001
+        assert result == "What is this?"
+
+    def test_extract_first_sentence_empty(self, enricher):
+        """Test empty text returns None."""
+        result = enricher._extract_first_sentence("")  # noqa: SLF001
+        assert result is None
+
+    def test_extract_first_sentence_none(self, enricher):
+        """Test None text returns None."""
+        result = enricher._extract_first_sentence(None)  # type: ignore[arg-type]  # noqa: SLF001
+        assert result is None
+
+
+class TestStyleTransformations:
+    """Test style transformation to imperative tone."""
+
+    def test_transform_the_x_is_pattern(self, enricher):
+        """Test transforming 'The X is used to...' pattern."""
+        text = "The configuration is used to specify options."
+        result = enricher._apply_style_rules(text)  # noqa: SLF001
+        assert result.startswith("Specifies") or "configuration" in result.lower()
+
+    def test_transform_this_field_pattern(self, enricher):
+        """Test transforming 'This field specifies...' pattern."""
+        text = "This field specifies the timeout value."
+        result = enricher._apply_style_rules(text)  # noqa: SLF001
+        # Should remove "This field specifies"
+        assert not result.lower().startswith("this field")
+
+    def test_transform_an_article_pattern(self, enricher):
+        """Test removing leading article 'An/A'."""
+        text = "An option for configuring the system."
+        result = enricher._apply_style_rules(text)  # noqa: SLF001
+        # Should remove leading "An"
+        assert not result.startswith("An ")
+
+    def test_capitalize_first_letter(self, enricher):
+        """Test first letter is capitalized."""
+        text = "lowercase start of sentence."
+        result = enricher._apply_style_rules(text)  # noqa: SLF001
+        assert result[0].isupper()
+
+
+class TestDescriptionCleaning:
+    """Test description cleaning functionality."""
+
+    def test_remove_examples(self, enricher):
+        """Test removal of example sections."""
+        text = "Configure the system. Example: config.yaml contains settings."
+        result = enricher._clean_description(text)  # noqa: SLF001
+        assert "Example:" not in result
+
+    def test_remove_http_links(self, enricher):
+        """Test removal of HTTP links."""
+        text = "See documentation. For more info see https://docs.example.com/page."
+        result = enricher._clean_description(text)  # noqa: SLF001
+        assert "https://" not in result
+
+    def test_remove_inline_code(self, enricher):
+        """Test removal of inline code blocks."""
+        text = "Use the `config` command to set values."
+        result = enricher._clean_description(text)  # noqa: SLF001
+        assert "`config`" not in result
+
+    def test_remove_code_blocks(self, enricher):
+        """Test removal of code blocks."""
+        text = "Configure like this: ```yaml\nkey: value\n``` Then proceed."
+        result = enricher._clean_description(text)  # noqa: SLF001
+        assert "```" not in result
+
+    def test_normalize_whitespace(self, enricher):
+        """Test whitespace normalization."""
+        text = "Multiple   spaces   and\nnewlines\tand tabs."
+        result = enricher._clean_description(text)  # noqa: SLF001
+        assert "  " not in result
+        assert "\n" not in result
+        assert "\t" not in result
+
+
+class TestSmartTruncation:
+    """Test smart truncation functionality."""
+
+    def test_truncate_at_word_boundary(self, enricher):
+        """Test truncation happens at word boundaries."""
+        text = "This is a very long description that needs to be truncated properly."
+        result = enricher._smart_truncate(text, 30)  # noqa: SLF001
+        # Should end with ellipsis and not cut mid-word
+        assert result.endswith("...")
+        assert len(result) <= 30
+
+    def test_truncate_preserves_short_text(self, enricher):
+        """Test short text is not truncated."""
+        text = "Short text."
+        result = enricher._smart_truncate(text, 100)  # noqa: SLF001
+        assert result == text
+        assert "..." not in result
+
+    def test_truncate_removes_trailing_punctuation(self, enricher):
+        """Test trailing punctuation is removed before ellipsis."""
+        text = "A sentence, with punctuation, that gets cut."
+        result = enricher._smart_truncate(text, 30)  # noqa: SLF001
+        # Should not end with ",...""
+        assert not result.endswith(",...")
+
+
+class TestConfigurationOverrides:
+    """Test configuration-based overrides."""
+
+    def test_has_override(self, enricher):
+        """Test checking for override existence."""
+        # Assuming default config has some overrides
+        # The actual key depends on config file
+        has = enricher.has_override("schemavirtual_hostCreateSpecType", "domains")
+        # This tests the method works; actual result depends on config
+        assert isinstance(has, bool)
+
+    def test_get_override(self, enricher):
+        """Test getting override value."""
+        result = enricher.get_override("schemavirtual_hostCreateSpecType", "domains")
+        # If override exists, should return string
+        if result is not None:
+            assert isinstance(result, str)
+            assert len(result) > 0
+
+
+class TestPatternTemplates:
+    """Test pattern-based template matching."""
+
+    def test_pattern_template_creation(self):
+        """Test creating a pattern template."""
+        template = PatternTemplate(
+            pattern=re.compile(r"\.domains$"),
+            template="List of domain names for this resource.",
+        )
+        assert template.pattern.search("config.domains") is not None
+        assert template.template == "List of domain names for this resource."
+
+    def test_pattern_matching_domains(self, enricher):
+        """Test that .domains pattern matches."""
+        # Internal method test - check pattern matching works
+        for pattern_template in enricher.patterns:
+            if pattern_template.pattern.search("domains"):
+                assert pattern_template.template is not None
+                break
+
+
+class TestSpecEnrichment:
+    """Test full specification enrichment."""
+
+    def test_enrich_spec_with_long_description(
+        self,
+        enricher,
+        spec_with_long_descriptions,
+    ):
+        """Test enriching spec with long descriptions."""
+        result = enricher.enrich_spec(spec_with_long_descriptions)
+
+        # Check structure preserved
+        assert "components" in result
+        assert "schemas" in result["components"]
+        assert "TestSchema" in result["components"]["schemas"]
+
+        # Check that js_challenge got short description
+        js_challenge = result["components"]["schemas"]["TestSchema"]["properties"]["js_challenge"]
+        assert X_F5XC_DESCRIPTION_SHORT in js_challenge
+
+        # Check short description length
+        short_desc = js_challenge[X_F5XC_DESCRIPTION_SHORT]
+        assert len(short_desc) >= 40  # Minimum reasonable length
+        assert len(short_desc) <= 150  # Max target length
+
+    def test_enrich_spec_skips_short_descriptions(
+        self,
+        enricher,
+        spec_with_long_descriptions,
+    ):
+        """Test that short descriptions are skipped."""
+        result = enricher.enrich_spec(spec_with_long_descriptions)
+
+        # Name property has short description - should not get extension
+        name_prop = result["components"]["schemas"]["TestSchema"]["properties"]["name"]
+        assert X_F5XC_DESCRIPTION_SHORT not in name_prop
+
+    def test_stats_after_enrichment(self, enricher, spec_with_long_descriptions):
+        """Test stats are updated after enrichment."""
+        enricher.enrich_spec(spec_with_long_descriptions)
+        stats = enricher.get_stats()
+
+        assert stats["schemas_processed"] >= 1
+        assert stats["fields_processed"] >= 2
+        assert stats["short_descriptions_added"] >= 1
+        assert stats["skipped_already_short"] >= 1
+
+
+class TestNestedSchemas:
+    """Test handling of nested schemas."""
+
+    def test_allof_schemas_processed(self, enricher, long_description):
+        """Test that allOf schemas are processed."""
+        spec = {
+            "components": {
+                "schemas": {
+                    "Combined": {
+                        "allOf": [
+                            {
+                                "type": "object",
+                                "properties": {
+                                    "config": {
+                                        "type": "object",
+                                        "description": long_description,
+                                    },
+                                },
+                            },
+                        ],
+                    },
+                },
+            },
+        }
+
+        result = enricher.enrich_spec(spec)
+        config_prop = result["components"]["schemas"]["Combined"]["allOf"][0]["properties"][
+            "config"
+        ]
+        assert X_F5XC_DESCRIPTION_SHORT in config_prop
+
+    def test_oneof_schemas_processed(self, enricher, long_description):
+        """Test that oneOf schemas are processed."""
+        spec = {
+            "components": {
+                "schemas": {
+                    "Choice": {
+                        "oneOf": [
+                            {
+                                "type": "object",
+                                "properties": {
+                                    "option": {
+                                        "type": "string",
+                                        "description": long_description,
+                                    },
+                                },
+                            },
+                        ],
+                    },
+                },
+            },
+        }
+
+        result = enricher.enrich_spec(spec)
+        option_prop = result["components"]["schemas"]["Choice"]["oneOf"][0]["properties"]["option"]
+        assert X_F5XC_DESCRIPTION_SHORT in option_prop
+
+    def test_items_schema_processed(self, enricher, long_description):
+        """Test that array items schemas are processed."""
+        spec = {
+            "components": {
+                "schemas": {
+                    "List": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "element": {
+                                    "type": "string",
+                                    "description": long_description,
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        }
+
+        result = enricher.enrich_spec(spec)
+        element_prop = result["components"]["schemas"]["List"]["items"]["properties"]["element"]
+        assert X_F5XC_DESCRIPTION_SHORT in element_prop
+
+
+class TestPreserveExisting:
+    """Test preservation of existing extensions."""
+
+    def test_preserve_existing_extension(self, enricher, long_description):
+        """Test that existing x-f5xc-description-short is preserved."""
+        existing_short = "Existing short description."
+        spec = {
+            "components": {
+                "schemas": {
+                    "Test": {
+                        "type": "object",
+                        "properties": {
+                            "config": {
+                                "type": "object",
+                                "description": long_description,
+                                X_F5XC_DESCRIPTION_SHORT: existing_short,
+                            },
+                        },
+                    },
+                },
+            },
+        }
+
+        result = enricher.enrich_spec(spec)
+        config_prop = result["components"]["schemas"]["Test"]["properties"]["config"]
+
+        # Should preserve existing
+        assert config_prop[X_F5XC_DESCRIPTION_SHORT] == existing_short
+
+        # Stats should show skipped
+        stats = enricher.get_stats()
+        assert stats["skipped_has_extension"] >= 1
+
+
+class TestEdgeCases:
+    """Test edge cases and error conditions."""
+
+    def test_empty_spec(self, enricher):
+        """Test enriching empty spec."""
+        result = enricher.enrich_spec({})
+        assert result == {}
+
+    def test_spec_without_schemas(self, enricher):
+        """Test enriching spec without schemas."""
+        spec = {"info": {"title": "Test API"}, "paths": {}}
+        result = enricher.enrich_spec(spec)
+        assert result is not None
+
+    def test_null_property_values(self, enricher):
+        """Test handling null property values."""
+        spec = {
+            "components": {
+                "schemas": {
+                    "Test": {
+                        "type": "object",
+                        "properties": {
+                            "name": None,
+                        },
+                    },
+                },
+            },
+        }
+
+        result = enricher.enrich_spec(spec)
+        # Should not raise, should preserve null
+        assert result["components"]["schemas"]["Test"]["properties"]["name"] is None
+
+    def test_property_without_description(self, enricher):
+        """Test property without description field."""
+        spec = {
+            "components": {
+                "schemas": {
+                    "Test": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"},
+                        },
+                    },
+                },
+            },
+        }
+
+        result = enricher.enrich_spec(spec)
+        # Should not add short description to property without long description
+        name_prop = result["components"]["schemas"]["Test"]["properties"]["name"]
+        assert X_F5XC_DESCRIPTION_SHORT not in name_prop
+
+    def test_empty_description(self, enricher):
+        """Test property with empty description."""
+        spec = {
+            "components": {
+                "schemas": {
+                    "Test": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string", "description": ""},
+                        },
+                    },
+                },
+            },
+        }
+
+        result = enricher.enrich_spec(spec)
+        name_prop = result["components"]["schemas"]["Test"]["properties"]["name"]
+        assert X_F5XC_DESCRIPTION_SHORT not in name_prop
+
+
+class TestLengthValidation:
+    """Test description length validation."""
+
+    def test_generated_description_within_target(self, enricher, long_description):
+        """Test generated descriptions are within target range."""
+        short_desc = enricher._extract_and_transform(long_description)  # noqa: SLF001
+
+        if short_desc:
+            # Should be at least 40 chars (relaxed minimum for some extractions)
+            assert len(short_desc) >= 40
+            # Should be at most 150 chars (max target)
+            assert len(short_desc) <= 150
+
+    def test_boundary_length_description(self, enricher):
+        """Test description exactly at 300 char boundary."""
+        # Create description exactly 300 chars
+        desc_300 = "X" * 299 + "."
+        assert len(desc_300) == 300
+
+        spec = {
+            "components": {
+                "schemas": {
+                    "Test": {
+                        "type": "object",
+                        "properties": {
+                            "field": {"type": "string", "description": desc_300},
+                        },
+                    },
+                },
+            },
+        }
+
+        result = enricher.enrich_spec(spec)
+        field_prop = result["components"]["schemas"]["Test"]["properties"]["field"]
+        # At exactly 300 chars, should NOT be processed (min_source_length is 300)
+        assert X_F5XC_DESCRIPTION_SHORT not in field_prop
+
+    def test_just_over_boundary_processed(self, enricher):
+        """Test description just over 300 chars is processed."""
+        # Create description 301 chars
+        desc_301 = "X" * 300 + "."
+        assert len(desc_301) == 301
+
+        spec = {
+            "components": {
+                "schemas": {
+                    "Test": {
+                        "type": "object",
+                        "properties": {
+                            "field": {"type": "string", "description": desc_301},
+                        },
+                    },
+                },
+            },
+        }
+
+        result = enricher.enrich_spec(spec)
+        field_prop = result["components"]["schemas"]["Test"]["properties"]["field"]
+        # At 301 chars, should be processed
+        assert X_F5XC_DESCRIPTION_SHORT in field_prop
+
+
+class TestIdempotency:
+    """Test idempotent enrichment behavior."""
+
+    def test_multiple_enrichment_idempotent(self, enricher, spec_with_long_descriptions):
+        """Test that running enrichment twice produces same result."""
+        # First enrichment
+        result1 = enricher.enrich_spec(spec_with_long_descriptions)
+        short_desc1 = result1["components"]["schemas"]["TestSchema"]["properties"][
+            "js_challenge"
+        ].get(X_F5XC_DESCRIPTION_SHORT)
+
+        # Create new enricher and enrich again
+        enricher2 = PropertyDescriptionShortEnricher()
+        result2 = enricher2.enrich_spec(result1)
+        short_desc2 = result2["components"]["schemas"]["TestSchema"]["properties"][
+            "js_challenge"
+        ].get(X_F5XC_DESCRIPTION_SHORT)
+
+        # Should be identical (preserved)
+        assert short_desc1 == short_desc2
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Implements Issue #330: Generate concise 80-150 character descriptions for schema properties with long descriptions (>300 chars) to support Terraform provider documentation.

### Features
- **PropertyDescriptionShortEnricher class** with multi-tier generation approach:
  1. Configuration override (highest priority)
  2. Pattern-based templates for common field names
  3. First sentence extraction with style transformation

- **Azure/AWS Terraform style conventions**:
  - Imperative tone: "Specifies...", "Enables...", "Configures..."
  - Single sentence, no code examples
  - Includes defaults and constraints inline

- **Smart processing**:
  - Only targets descriptions >300 characters
  - Preserves existing `x-f5xc-description-short` extensions
  - Smart truncation at word boundaries

### Files Changed
- **New**: `scripts/utils/property_description_short_enricher.py` - Core enricher class
- **New**: `config/property_description_short.yaml` - Configuration with overrides and patterns
- **New**: `tests/test_property_description_short_enricher.py` - 46 comprehensive tests
- **Modified**: `scripts/pipeline.py` - Integrated as pipeline step 12
- **Modified**: `scripts/utils/__init__.py` - Added export

### Example Output

```json
{
  "properties": {
    "endpoint_subsets": {
      "description": "[long original description of 500+ chars...]",
      "x-f5xc-description-short": "Endpoint groups based on metadata labels for traffic routing."
    }
  }
}
```

## Test plan

- [x] 46 unit tests covering all functionality
- [x] Pre-commit hooks pass (pipeline, linting, ruff, mypy)
- [x] Pipeline integrates correctly as step 12

Closes #331

🤖 Generated with [Claude Code](https://claude.com/claude-code)