### PR TITLE
fix: Remove 'API' suffix from domain description fallbacks

### DIFF
--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -1327,9 +1327,8 @@ def create_spec_index(domain_specs: dict[str, dict[str, Any]], version: str) -> 
             "domain": domain,
             "title": info.get("title", ""),
             "description": info.get("description", ""),
-            X_F5XC_DESCRIPTION_SHORT: description_short or f"{domain_title} API",
-            X_F5XC_DESCRIPTION_MEDIUM: description_medium
-            or f"F5 Distributed Cloud {domain_title} API specifications",
+            X_F5XC_DESCRIPTION_SHORT: description_short or domain_title,
+            X_F5XC_DESCRIPTION_MEDIUM: description_medium or f"F5 Distributed Cloud {domain_title}",
             "file": f"{domain}.json",
             "path_count": path_count,
             "schema_count": schema_count,


### PR DESCRIPTION
## Summary

Remove self-referential 'API' suffixes from domain description fallbacks in the enrichment pipeline.

### Changes

- **scripts/pipeline.py**: Remove ' API' suffix from `description_short` fallback
- **scripts/pipeline.py**: Remove ' API specifications' suffix from `description_medium` fallback

### Issues Resolved

- **#346**: Violation: Domain descriptions ending with 'API' suffix are self-referential
- **#347**: Complete LLM Coverage Initiative: Eliminate API Suffix Violations
- **#360**: Tracking issue for this fix

### Impact

- Eliminates style violations in downstream tools like `xcsh --help`
- Removes redundant 'API' suffixes from descriptions in API documentation
- Ensures consistent, non-self-referential domain descriptions

### Testing

- Pipeline runs successfully with no API suffix violations
- Generated `index.json` contains no 'API' suffixes in descriptions
- All existing domain descriptions with proper fallbacks remain unchanged