### PR TITLE
fix: improve 5 domain descriptions with specific content

### DIFF
--- a/config/domain_descriptions.yaml
+++ b/config/domain_descriptions.yaml
@@ -353,40 +353,37 @@ domains:
       validates rules before enforcement. Security event metrics track rule hits and
       blocked requests across namespaces.
   authentication:
-    short: Authentication management and configuration
-    medium: Configure and manage authentication settings, policies, and resources
+    short: Authentication settings, policies, and user management.
+    medium: Configure authentication providers, access policies, and user credentials
       across your F5 Distributed Cloud deployment.
     long: Authentication management for F5 Distributed Cloud. Provides APIs for configuring
-      authentication, managing associated resources, and integrating with other platform
-      services. Supports lifecycle operations, policy enforcement, and observability.
+      authentication providers, access policies, and user credentials. Supports lifecycle
+      operations, multi-factor authentication, and identity provider integration.
   data_intelligence:
-    short: Data Intelligence management and configuration
+    short: Data Intelligence settings, policies, and resource management.
     medium: Configure and manage data intelligence settings, policies, and resources
       across your F5 Distributed Cloud deployment.
     long: Data Intelligence management for F5 Distributed Cloud. Provides APIs for
-      configuring data intelligence, managing associated resources, and integrating
-      with other platform services. Supports lifecycle operations, policy enforcement,
-      and observability.
+      configuring data intelligence policies and resources. Supports data classification,
+      insight generation, and integration with security services.
   telemetry_and_insights:
-    short: Telemetry And Insights management and configuration
-    medium: Configure and manage telemetry and insights settings, policies, and resources
+    short: Telemetry and insights collection, analysis, and visualization.
+    medium: Configure telemetry collection, metrics analysis, and insight generation
       across your F5 Distributed Cloud deployment.
-    long: Telemetry And Insights management for F5 Distributed Cloud. Provides APIs
-      for configuring telemetry and insights, managing associated resources, and integrating
-      with other platform services. Supports lifecycle operations, policy enforcement,
-      and observability.
+    long: Telemetry and insights management for F5 Distributed Cloud. Provides APIs
+      for configuring telemetry collection, metrics storage, and insight generation.
+      Supports log aggregation, performance monitoring, and alerting integration.
   threat_campaign:
-    short: Threat Campaign management and configuration
-    medium: Configure and manage threat campaign settings, policies, and resources
+    short: Threat campaign detection, tracking, and mitigation policies.
+    medium: Configure threat campaign detection, tracking, and mitigation policies
       across your F5 Distributed Cloud deployment.
-    long: Threat Campaign management for F5 Distributed Cloud. Provides APIs for configuring
-      threat campaign, managing associated resources, and integrating with other platform
-      services. Supports lifecycle operations, policy enforcement, and observability.
+    long: Threat campaign management for F5 Distributed Cloud. Provides APIs for
+      configuring threat campaign detection and tracking policies. Supports campaign
+      analysis, risk assessment, and mitigation rule generation.
   vpm_and_node_management:
-    short: Vpm And Node Management management and configuration
-    medium: Configure and manage vpm and node management settings, policies, and resources
+    short: VPM and node management, configuration, and lifecycle operations.
+    medium: Configure VPM and node management settings, policies, and resources
       across your F5 Distributed Cloud deployment.
-    long: Vpm And Node Management management for F5 Distributed Cloud. Provides APIs
-      for configuring vpm and node management, managing associated resources, and
-      integrating with other platform services. Supports lifecycle operations, policy
-      enforcement, and observability.
+    long: VPM and node management for F5 Distributed Cloud. Provides APIs for
+      configuring node policies, fleet management, and lifecycle operations. Supports
+      node registration, configuration deployment, and status monitoring.


### PR DESCRIPTION
Improved 5 fallback domain descriptions in config/domain_descriptions.yaml:

- authentication: settings, policies, and user management
- data_intelligence: settings, policies, and resource management  
- telemetry_and_insights: collection, analysis, and visualization
- threat_campaign: detection, tracking, and mitigation policies
- vpm_and_node_management: configuration, and lifecycle operations

All short descriptions now end with periods and are more descriptive.