### PR TITLE
chore: update project licensing to MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Robin Mordasiewicz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,7 @@
 site_name: F5 Distributed Cloud API Documentation
-site_description: Comprehensive API documentation for F5 XC services including load balancing, security, networking, and infrastructure management
+site_description: >-
+  Comprehensive API documentation for F5 XC services including
+  load balancing, security, networking, and infrastructure management
 site_author: F5 Distributed Cloud
 site_url: https://robinmordasiewicz.github.io/f5xc-api-enriched/
 
@@ -83,13 +85,13 @@ extra:
 nav:
   - Home: index.md
   - API Viewers:
-    - Swagger UI: swagger-ui.md
-    - Scalar: scalar.md
+      - Swagger UI: swagger-ui.md
+      - Scalar: scalar.md
   - Development: DEVELOPMENT.md
   - Specifications:
-    - API Index: specifications/index.md
+      - API Index: specifications/index.md
 
 extra_css:
   - stylesheets/extra.css
 
-copyright: Copyright &copy; F5, Inc. All rights reserved.
+copyright: Copyright © 2026 Robin Mordasiewicz | MIT License

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,1 +1,3 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """F5 XC API Enrichment Scripts."""

--- a/scripts/analyze_constraints.py
+++ b/scripts/analyze_constraints.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Constraint Analysis CLI.
 
 Compares published API specifications with discovered real-world constraints,

--- a/scripts/discover.py
+++ b/scripts/discover.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """F5 XC API Discovery Script.
 
 Systematically explores the live authenticated F5 XC API to discover

--- a/scripts/discovery/__init__.py
+++ b/scripts/discovery/__init__.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """F5 XC API Discovery Package.
 
 Systematically explores live API to discover undocumented behavior:

--- a/scripts/discovery/cli_explorer.py
+++ b/scripts/discovery/cli_explorer.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """xcsh CLI integration for API discovery.
 
 Uses the xcsh command-line tool (F5 Distributed Cloud Shell) to:

--- a/scripts/discovery/diff_analyzer.py
+++ b/scripts/discovery/diff_analyzer.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Schema diff analyzer for comparing published vs discovered APIs.
 
 Compares published OpenAPI specs with discovered behavior to detect:

--- a/scripts/discovery/error_catalog_builder.py
+++ b/scripts/discovery/error_catalog_builder.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Error catalog builder for API discovery.
 
 Catalogs error responses discovered during API exploration,

--- a/scripts/discovery/percentile_collector.py
+++ b/scripts/discovery/percentile_collector.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Response time percentile collector for API discovery.
 
 Collects multiple response time samples and calculates statistical

--- a/scripts/discovery/rate_limit_discoverer.py
+++ b/scripts/discovery/rate_limit_discoverer.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Rate limit discoverer for API endpoints.
 
 Safely probes API endpoints to characterize rate limiting behavior.

--- a/scripts/discovery/rate_limiter.py
+++ b/scripts/discovery/rate_limiter.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Async rate limiter with exponential backoff.
 
 Provides rate limiting for API discovery to avoid throttling.

--- a/scripts/discovery/report_generator.py
+++ b/scripts/discovery/report_generator.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Report generator for API discovery results.
 
 Generates:

--- a/scripts/discovery/schema_inferrer.py
+++ b/scripts/discovery/schema_inferrer.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """JSON Schema inference from API responses.
 
 Analyzes live API responses to infer:

--- a/scripts/download.py
+++ b/scripts/download.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Download and extract F5 XC API specifications from the official source."""
 
 import argparse

--- a/scripts/enrich.py
+++ b/scripts/enrich.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Automated enrichment pipeline for F5 XC API specifications.
 
 Applies acronym normalization, grammar improvements, and branding transformations

--- a/scripts/ensure_labels.py
+++ b/scripts/ensure_labels.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Ensure GitHub Labels Script.
 
 Creates required labels for workflow monitoring if they don't exist.

--- a/scripts/generate_descriptions.py
+++ b/scripts/generate_descriptions.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Generate enriched domain descriptions using OpenCode.
 
 Uses OpenCode API in non-interactive mode to generate 3-tier descriptions

--- a/scripts/hooks/pre-commit-pipeline.sh
+++ b/scripts/hooks/pre-commit-pipeline.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 # Pre-commit hook: Regenerate enriched specs and validate on every commit
 #
 # IMPORTANT: This hook validates ALL files on every commit, including:

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Lint OpenAPI specifications using Spectral.
 
 Validates specifications against OpenAPI standards and custom rules before merge.

--- a/scripts/merge_specs.py
+++ b/scripts/merge_specs.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Merge multiple OpenAPI specifications into unified documents for documentation.
 
 Creates merged specifications organized by domain for Swagger UI and Scalar portals.

--- a/scripts/monitor_workflow.py
+++ b/scripts/monitor_workflow.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Workflow Monitoring Script.
 
 Analyzes GitHub Actions workflow runs for failures and creates/updates issues.

--- a/scripts/normalize.py
+++ b/scripts/normalize.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Normalize OpenAPI specifications to fix structural issues.
 
 Resolves orphan $ref references, removes empty operations, and ensures

--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Unified F5 XC API Enrichment Pipeline.
 
 Single command to process all specifications from original → enriched.

--- a/scripts/utils/__init__.py
+++ b/scripts/utils/__init__.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Utility modules for F5 XC API enrichment."""
 
 from .acronym_enricher import AcronymEnricher

--- a/scripts/utils/acronym_enricher.py
+++ b/scripts/utils/acronym_enricher.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Acronym Enricher for OpenAPI specifications.
 
 Applies structured technical terminology from config/acronyms.yaml

--- a/scripts/utils/acronyms.py
+++ b/scripts/utils/acronyms.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Automated acronym normalization for API specification text fields."""
 
 import re

--- a/scripts/utils/best_practices_enricher.py
+++ b/scripts/utils/best_practices_enricher.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Best Practices Enricher for OpenAPI specifications.
 
 Applies domain-specific operational knowledge from config/best_practices.yaml

--- a/scripts/utils/branding.py
+++ b/scripts/utils/branding.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Automated branding transformations for API specification text fields.
 
 Applies consistent F5 branding by replacing legacy Volterra references

--- a/scripts/utils/consistency_validator.py
+++ b/scripts/utils/consistency_validator.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Consistency validator for OpenAPI specifications.
 
 Validates naming conventions and structural consistency,

--- a/scripts/utils/constraint_analyzer.py
+++ b/scripts/utils/constraint_analyzer.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Constraint Analyzer Module.
 
 Compares published API constraints with discovered real-world constraints,

--- a/scripts/utils/constraint_reconciler.py
+++ b/scripts/utils/constraint_reconciler.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Constraint Reconciler Module.
 
 Reconciles discovered API constraints from x-discovered-* extensions

--- a/scripts/utils/curl_validator.py
+++ b/scripts/utils/curl_validator.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """CRUD validation for curl examples against live F5 XC API.
 
 Validates curl examples by executing actual Create, Read, Update, Delete

--- a/scripts/utils/deprecated_tier_enricher.py
+++ b/scripts/utils/deprecated_tier_enricher.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Deprecated tier transformation enricher for OpenAPI specifications.
 
 This enricher transforms deprecated subscription tier values to their

--- a/scripts/utils/description_enricher.py
+++ b/scripts/utils/description_enricher.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Domain Description Enricher for OpenAPI specifications.
 
 Applies enriched domain descriptions from config/domain_descriptions.yaml

--- a/scripts/utils/description_structure.py
+++ b/scripts/utils/description_structure.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Description structure normalization for API specifications.
 
 Extracts embedded metadata (examples, validation rules) to proper fields

--- a/scripts/utils/description_validator.py
+++ b/scripts/utils/description_validator.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Description validator for OpenAPI specifications.
 
 Validates description completeness and auto-generates missing descriptions

--- a/scripts/utils/discovery_enricher.py
+++ b/scripts/utils/discovery_enricher.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Discovery Enricher Module.
 
 Merges live API discovery data into published OpenAPI specifications,

--- a/scripts/utils/domain_categorizer.py
+++ b/scripts/utils/domain_categorizer.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Domain categorization utility for F5 XC API specifications.
 
 This module provides centralized domain categorization patterns for categorizing

--- a/scripts/utils/domain_metadata.py
+++ b/scripts/utils/domain_metadata.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Generate and manage domain metadata for CLI tool integration.
 
 This utility provides programmatic assignment of metadata fields to domains

--- a/scripts/utils/error_resolution_enricher.py
+++ b/scripts/utils/error_resolution_enricher.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Error Resolution Enricher for OpenAPI specifications.
 
 Applies HTTP error diagnostics from config/error_resolution.yaml

--- a/scripts/utils/extension_constants.py
+++ b/scripts/utils/extension_constants.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Centralized constants for x-f5xc-* OpenAPI extension namespace.
 
 This module provides:

--- a/scripts/utils/external_docs_enricher.py
+++ b/scripts/utils/external_docs_enricher.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """External documentation enricher for OpenAPI specifications.
 
 This enricher adds externalDocs metadata to OpenAPI specs,

--- a/scripts/utils/field_description_enricher.py
+++ b/scripts/utils/field_description_enricher.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Field Description and Example Enricher for OpenAPI specifications.
 
 Adds comprehensive descriptions and realistic examples to schema properties

--- a/scripts/utils/field_metadata_enricher.py
+++ b/scripts/utils/field_metadata_enricher.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Unified Field-Level Metadata Enricher for OpenAPI specifications.
 
 Consolidates and extends field-level enrichment with:

--- a/scripts/utils/grammar.py
+++ b/scripts/utils/grammar.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Automated grammar improvement for API specification text fields.
 
 Uses language-tool-python for automated grammar checking and correction.

--- a/scripts/utils/guided_workflow_enricher.py
+++ b/scripts/utils/guided_workflow_enricher.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Guided Workflow Enricher for OpenAPI specifications.
 
 Applies step-by-step deployment workflows from config/guided_workflows.yaml

--- a/scripts/utils/lint_reporter.py
+++ b/scripts/utils/lint_reporter.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Lint report generator for OpenAPI specification validation.
 
 Extracts report generation logic from lint.py into a reusable reporter class

--- a/scripts/utils/minimum_configuration_enricher.py
+++ b/scripts/utils/minimum_configuration_enricher.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Minimum configuration metadata enricher for OpenAPI specifications.
 
 This enricher adds minimum configuration metadata to resource schemas,

--- a/scripts/utils/namespace_scope_enricher.py
+++ b/scripts/utils/namespace_scope_enricher.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Namespace scope metadata enricher for OpenAPI specifications.
 
 This enricher adds namespace scope metadata to OpenAPI specs,

--- a/scripts/utils/operation_metadata_enricher.py
+++ b/scripts/utils/operation_metadata_enricher.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Operation Metadata Enricher for OpenAPI specifications.
 
 Adds operation-level metadata for CLI tooling:

--- a/scripts/utils/path_config.py
+++ b/scripts/utils/path_config.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Centralized path configuration management for F5 XC API pipeline.
 
 Provides a singleton PathConfig class that manages all directory and file paths

--- a/scripts/utils/property_description_short_enricher.py
+++ b/scripts/utils/property_description_short_enricher.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Property Description Enricher for OpenAPI specifications.
 
 Generates concise descriptions for schema properties with long descriptions (>300 chars):

--- a/scripts/utils/readonly_enricher.py
+++ b/scripts/utils/readonly_enricher.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """ReadOnly Field Enricher for OpenAPI specifications.
 
 Adds `readOnly: true` to API-computed fields following the OpenAPI 3.0 standard.

--- a/scripts/utils/report_base.py
+++ b/scripts/utils/report_base.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Base reporter class for all documentation generators.
 
 Provides abstract base class and common utilities for generating both

--- a/scripts/utils/resource_examples_enricher.py
+++ b/scripts/utils/resource_examples_enricher.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Resource Examples Enricher for OpenAPI specifications.
 
 Provides tiered resource configuration examples (minimal, production, advanced, migration)

--- a/scripts/utils/schema_fixer.py
+++ b/scripts/utils/schema_fixer.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Schema fixer for OpenAPI specifications.
 
 Fixes malformed schema definitions that violate OpenAPI 3.0.3 specification,

--- a/scripts/utils/server_variables.py
+++ b/scripts/utils/server_variables.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Server variables helper for F5 XC API OpenAPI specifications.
 
 Centralizes server variable configuration and URL template construction

--- a/scripts/utils/server_variables_markdown.py
+++ b/scripts/utils/server_variables_markdown.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Server variables markdown rendering utilities.
 
 Centralizes server variables rendering for all documentation generators,

--- a/scripts/utils/tag_generator.py
+++ b/scripts/utils/tag_generator.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Tag generator for OpenAPI specifications.
 
 Generates and assigns tags to operations based on path patterns,

--- a/scripts/utils/validation_enricher.py
+++ b/scripts/utils/validation_enricher.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Validation Rule Enricher for OpenAPI specifications.
 
 Adds OpenAPI validation constraints (pattern, minLength, maxLength, minimum, maximum, etc.)

--- a/scripts/utils/validation_reporter.py
+++ b/scripts/utils/validation_reporter.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Validation report generator for live API testing.
 
 Extracts report generation logic from validate.py into a reusable reporter class

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Automated validation of enriched API specifications against live F5 XC endpoints.
 
 Validates endpoint availability and response schema conformance.

--- a/scripts/validate_curl_examples.py
+++ b/scripts/validate_curl_examples.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Validate curl examples by executing CRUD operations against live F5 XC API.
 
 This script tests the curl examples from config/minimum_configs.yaml by

--- a/scripts/validate_domain_categorization.py
+++ b/scripts/validate_domain_categorization.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Validate domain categorization against natural identifiers in original specs.
 
 This script compares the current regex-based domain categorization

--- a/test_branding.py
+++ b/test_branding.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Test script to validate CLI branding transformations.
 
 Tests that:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,3 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Test suite for F5 XC API enrichment pipeline."""

--- a/tests/test_acronym_enricher.py
+++ b/tests/test_acronym_enricher.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Unit tests for AcronymEnricher."""
 
 import pytest

--- a/tests/test_best_practices_enricher.py
+++ b/tests/test_best_practices_enricher.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Unit tests for BestPracticesEnricher."""
 
 import pytest

--- a/tests/test_branding_normalizer.py
+++ b/tests/test_branding_normalizer.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Unit tests for BrandingNormalizer and XCKS/XCCS terminology transformations.
 
 Tests the BrandingNormalizer class for transforming legacy F5 XC Kubernetes

--- a/tests/test_critical_resources.py
+++ b/tests/test_critical_resources.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Unit tests for critical resources configuration and loading.
 
 Tests the x-ves-critical-resources extension added to index.json

--- a/tests/test_curl_validator.py
+++ b/tests/test_curl_validator.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Tests for CurlExampleValidator CRUD validation.
 
 Tests the validation of curl examples against live F5 XC API

--- a/tests/test_deprecated_tier_enricher.py
+++ b/tests/test_deprecated_tier_enricher.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Unit tests for DeprecatedTierEnricher."""
 
 from pathlib import Path

--- a/tests/test_description_enricher.py
+++ b/tests/test_description_enricher.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Unit tests for DescriptionEnricher."""
 
 import pytest

--- a/tests/test_description_validation.py
+++ b/tests/test_description_validation.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Tests for the 5-layer description validation system.
 
 Tests cover:

--- a/tests/test_discovery_enricher_operations.py
+++ b/tests/test_discovery_enricher_operations.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Tests for discovery enricher operation-level extensions.
 
 Tests the new operation-level enrichment functionality added in Issue #314:

--- a/tests/test_domain_categorizer.py
+++ b/tests/test_domain_categorizer.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Unit tests for domain categorization utility.
 
 Tests the DomainCategorizer class and module-level functions for categorizing

--- a/tests/test_domain_descriptions.py
+++ b/tests/test_domain_descriptions.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Tests that validate generated domain descriptions in config/domain_descriptions.yaml.
 
 Ensures all descriptions comply with DRY principles:

--- a/tests/test_domain_metadata.py
+++ b/tests/test_domain_metadata.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Unit tests for domain metadata utilities."""
 
 import pytest

--- a/tests/test_error_catalog_builder.py
+++ b/tests/test_error_catalog_builder.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Unit tests for ErrorCatalogBuilder module.
 
 Tests error catalog building functionality including configuration,

--- a/tests/test_error_resolution_enricher.py
+++ b/tests/test_error_resolution_enricher.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Unit tests for ErrorResolutionEnricher."""
 
 import pytest

--- a/tests/test_extension_naming.py
+++ b/tests/test_extension_naming.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Tests for extension naming constants and validation utilities.
 
 Version: v3.0.0 - Clean break, no backward compatibility

--- a/tests/test_external_docs_enricher.py
+++ b/tests/test_external_docs_enricher.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Tests for ExternalDocsEnricher.
 
 Tests the enrichment of OpenAPI specs with externalDocs metadata

--- a/tests/test_field_description_enricher.py
+++ b/tests/test_field_description_enricher.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Unit tests for FieldDescriptionEnricher."""
 
 from pathlib import Path

--- a/tests/test_field_metadata_enricher.py
+++ b/tests/test_field_metadata_enricher.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Unit tests for FieldMetadataEnricher."""
 
 from pathlib import Path

--- a/tests/test_guided_workflow_enricher.py
+++ b/tests/test_guided_workflow_enricher.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Unit tests for GuidedWorkflowEnricher."""
 
 import pytest

--- a/tests/test_minimum_configuration_enricher.py
+++ b/tests/test_minimum_configuration_enricher.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Tests for MinimumConfigurationEnricher.
 
 Tests the enrichment of OpenAPI specs with minimum configuration metadata

--- a/tests/test_namespace_scope_enricher.py
+++ b/tests/test_namespace_scope_enricher.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Tests for NamespaceScopeEnricher.
 
 Tests the enrichment of OpenAPI specs with namespace scope metadata

--- a/tests/test_operation_metadata_enricher.py
+++ b/tests/test_operation_metadata_enricher.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Unit tests for OperationMetadataEnricher."""
 
 from pathlib import Path

--- a/tests/test_operation_metadata_enricher_dual_format.py
+++ b/tests/test_operation_metadata_enricher_dual_format.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Unit tests for OperationMetadataEnricher dual-format functionality (Issue #139)."""
 
 import pytest

--- a/tests/test_percentile_collector.py
+++ b/tests/test_percentile_collector.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Unit tests for PercentileCollector."""
 
 # ruff: noqa: SLF001, TRY002, ERA001

--- a/tests/test_property_description_short_enricher.py
+++ b/tests/test_property_description_short_enricher.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Unit tests for PropertyDescriptionShortEnricher.
 
 Tests for Issue #330: Add x-f5xc-description-short and x-f5xc-description-medium extensions

--- a/tests/test_rate_limit_discoverer.py
+++ b/tests/test_rate_limit_discoverer.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Unit tests for RateLimitDiscoverer module.
 
 Tests rate limit discovery functionality including configuration,

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Unit tests for RateLimiter."""
 
 import asyncio

--- a/tests/test_readonly_enricher.py
+++ b/tests/test_readonly_enricher.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Unit tests for ReadOnlyEnricher.
 
 Tests the readOnly: true annotation added to API-computed fields

--- a/tests/test_resource_examples_enricher.py
+++ b/tests/test_resource_examples_enricher.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Unit tests for ResourceExamplesEnricher."""
 
 import pytest

--- a/tests/test_resource_metadata.py
+++ b/tests/test_resource_metadata.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Unit tests for per-resource metadata functionality (Issues #267-270).
 
 Tests resource metadata loading, structure validation, and integration

--- a/tests/test_validation_enricher.py
+++ b/tests/test_validation_enricher.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Unit tests for ValidationEnricher."""
 
 from pathlib import Path

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -1,1 +1,3 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Tests for utilities modules."""

--- a/tests/utils/test_path_config.py
+++ b/tests/utils/test_path_config.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Tests for path configuration management."""
 
 import sys

--- a/tests/utils/test_report_base.py
+++ b/tests/utils/test_report_base.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Tests for base reporter class."""
 
 import json

--- a/tests/utils/test_server_variables_markdown.py
+++ b/tests/utils/test_server_variables_markdown.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Tests for server variables markdown rendering."""
 
 import sys


### PR DESCRIPTION
## Summary

Update repository to explicitly adopt MIT License with proper copyright notices.

- Add MIT LICENSE file to repository root
- Add copyright headers to all Python source, test, and utility files
- Update mkdocs.yml copyright footer with new licensing information
- Correct YAML formatting issues in configuration

## Changes

- **LICENSE**: New file with MIT license text
- **mkdocs.yml**: Updated copyright notice and fixed indentation
- **All Python files**: Added copyright header at top of each file
  - Scripts (scripts/*.py)
  - Modules (scripts/discovery/*, scripts/utils/*)
  - Tests (tests/*)
  - Utilities and helpers

## Type

- [x] Chore
- [ ] Feature
- [ ] Bug Fix
- [ ] Breaking Change

## Related Issues

Closes #375

## Testing

- All pre-commit hooks pass (yamllint, check-yaml, etc.)
- No functional changes to code or API specifications
- Documentation and licensing only

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>