### PR TITLE
fix: handle download check-only exit codes correctly in workflow

### DIFF
--- a/.github/workflows/sync-and-enrich.yml
+++ b/.github/workflows/sync-and-enrich.yml
@@ -58,7 +58,25 @@ jobs:
             echo "updated=true" >> "$GITHUB_OUTPUT"
             echo "Push/dispatch event - forcing download"
           else
+            # Run check-only and capture exit code
+            # Exit code 1 = updates available (success for our purposes)
+            # Exit code 0 = no updates (also success)
+            # Other codes = actual error
+            set +e
             python -m scripts.download --check-only
+            EXIT_CODE=$?
+            set -e
+
+            if [ $EXIT_CODE -eq 1 ]; then
+              echo "Updates detected - will proceed with download"
+              exit 0
+            elif [ $EXIT_CODE -eq 0 ]; then
+              echo "No updates detected"
+              exit 0
+            else
+              echo "::error::Download check failed with exit code $EXIT_CODE"
+              exit $EXIT_CODE
+            fi
           fi
 
   sync-and-enrich:
@@ -432,22 +450,22 @@ jobs:
           BUMP_TYPE: ${{ steps.version.outputs.bump_type }}
         run: |
           set -e
-          
+
           BRANCH_NAME="version-bump/v${VERSION}"
-          
+
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
-          
+
           git checkout -b "$BRANCH_NAME"
           git add .version CHANGELOG.md .etag
-          
+
           if ! git diff --staged --quiet; then
             git commit -m "chore: bump version to v${VERSION} (${BUMP_TYPE} release)"
-            
+
             git push -u origin "$BRANCH_NAME" || true
-            
+
             PR_BODY="Automated version bump for ${BUMP_TYPE} release."
-            
+
             gh pr create \
               --title "chore: bump version to v${VERSION}" \
               --body "${PR_BODY}" \
@@ -455,7 +473,7 @@ jobs:
               --head "$BRANCH_NAME" \
               --label "release,autorelease" \
               --autoMerge || echo "Note: Enable auto-merge in repo settings for fully automated workflow"
-            
+
             echo "Version bump PR created: https://github.com/${{ github.repository }}/pulls"
           else
             echo "No changes to commit"


### PR DESCRIPTION
Closes #380

The sync-and-enrich workflow's download check step needs to properly handle exit codes from the download script's --check-only mode:
- Exit code 1 indicates updates are available (expected)
- Exit code 0 indicates no updates (expected)
- Other codes indicate actual errors

This fix adds explicit exit code handling with set +e/set -e to distinguish between these cases and ensure the workflow doesn't fail when updates are detected or absent.

Changes:
- Capture exit code from check-only download script
- Branch on exit code to handle three scenarios
- Preserve workflow continuation for valid states
- Error only on actual failures