### PR TITLE
fix: Replace sys.path manipulation with absolute imports (resolves #388)

### DIFF
--- a/scripts/utils/lint_reporter.py
+++ b/scripts/utils/lint_reporter.py
@@ -7,17 +7,13 @@ supporting both JSON and markdown output formats.
 """
 
 import logging
-import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-# Add utils to path for imports
-sys.path.insert(0, str(Path(__file__).parent))
-
-from path_config import PathConfig
-from report_base import BaseReporter
-from server_variables_markdown import ServerVariablesMarkdownHelper
+from scripts.utils.path_config import PathConfig
+from scripts.utils.report_base import BaseReporter
+from scripts.utils.server_variables_markdown import ServerVariablesMarkdownHelper
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/utils/report_base.py
+++ b/scripts/utils/report_base.py
@@ -8,16 +8,12 @@ markdown and JSON reports consistently across all generators.
 
 import json
 import logging
-import sys
 from abc import ABC, abstractmethod
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-# Add utils to path for imports
-sys.path.insert(0, str(Path(__file__).parent))
-
-from path_config import PathConfig
+from scripts.utils.path_config import PathConfig
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/utils/server_variables_markdown.py
+++ b/scripts/utils/server_variables_markdown.py
@@ -8,16 +8,12 @@ linting, and validation reports.
 """
 
 import logging
-import sys
 from pathlib import Path
 from typing import Any
 
 import yaml
 
-# Add utils to path for imports
-sys.path.insert(0, str(Path(__file__).parent))
-
-from report_base import BaseReporter
+from scripts.utils.report_base import BaseReporter
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/utils/validation_reporter.py
+++ b/scripts/utils/validation_reporter.py
@@ -7,17 +7,13 @@ supporting both JSON and markdown output formats.
 """
 
 import logging
-import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-# Add utils to path for imports
-sys.path.insert(0, str(Path(__file__).parent))
-
-from path_config import PathConfig
-from report_base import BaseReporter
-from server_variables_markdown import ServerVariablesMarkdownHelper
+from scripts.utils.path_config import PathConfig
+from scripts.utils.report_base import BaseReporter
+from scripts.utils.server_variables_markdown import ServerVariablesMarkdownHelper
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary

Removes sys.path.insert() anti-pattern from 4 reporter modules and replaces with proper absolute imports. This eliminates import fragility without introducing any circular dependencies.

Fixes #388

## Investigation Findings

**Good News**: NO actual circular dependencies exist in the codebase. All modules form a clean Directed Acyclic Graph (DAG).

**Real Problem**: Four modules used `sys.path.insert()` anti-pattern, creating import order sensitivity and maintenance hazards.

## Changes Made

### 1. scripts/utils/report_base.py
**Before**:
```python
import sys
sys.path.insert(0, str(Path(__file__).parent))
from path_config import PathConfig
```

**After**:
```python
from scripts.utils.path_config import PathConfig
```

### 2. scripts/utils/lint_reporter.py  
**Before**:
```python
import sys
sys.path.insert(0, str(Path(__file__).parent))
from path_config import PathConfig
from report_base import BaseReporter
from server_variables_markdown import ServerVariablesMarkdownHelper
```

**After**:
```python
from scripts.utils.path_config import PathConfig
from scripts.utils.report_base import BaseReporter
from scripts.utils.server_variables_markdown import ServerVariablesMarkdownHelper
```

### 3. scripts/utils/validation_reporter.py
**Before**:
```python
import sys
sys.path.insert(0, str(Path(__file__).parent))
from path_config import PathConfig
from report_base import BaseReporter
from server_variables_markdown import ServerVariablesMarkdownHelper
```

**After**:
```python
from scripts.utils.path_config import PathConfig
from scripts.utils.report_base import BaseReporter
from scripts.utils.server_variables_markdown import ServerVariablesMarkdownHelper
```

### 4. scripts/utils/server_variables_markdown.py
**Before**:
```python
import sys
sys.path.insert(0, str(Path(__file__).parent))
from report_base import BaseReporter
```

**After**:
```python
from scripts.utils.report_base import BaseReporter
```

## Benefits

| Benefit | Description |
|---------|-------------|
| **Explicit Dependencies** | Import relationships now clearly visible |
| **Import Order Independence** | Modules can be imported in any order |
| **Testing Reliability** | Unit tests no longer affected by import order |
| **Maintenance** | Standard Python patterns, easier to understand |
| **No Fragility** | Removes hidden sys.path manipulation |

## Impact

- **Files Modified**: 4
- **Lines Removed**: sys.path manipulation (24 lines)
- **Lines Added**: Absolute imports (8 lines)
- **Net Change**: -16 lines
- **Behavior Change**: None (functionality identical)

## Testing

```bash
# Direct import tests - all pass
python -c "from scripts.utils.lint_reporter import LintReporter"
python -c "from scripts.utils.validation_reporter import ValidationReporter"
python -c "from scripts.utils.report_base import BaseReporter"
python -c "from scripts.utils.server_variables_markdown import ServerVariablesMarkdownHelper"

# Full test suite - 1191 tests pass (same as before)
pytest tests/ -v
```

## Verification Checklist

- [x] Removed all sys.path.insert() calls
- [x] Replaced with absolute imports (scripts.utils.*)
- [x] All 1191 passing tests continue to pass
- [x] Import order independent (tested multiple import orders)
- [x] No new circular dependencies introduced
- [x] Pipeline execution successful

## Priority

**High** - Eliminates unpredictable runtime failures due to import order sensitivity.

## Risk Assessment

**Risk**: LOW
- No behavior changes
- Simple import refactoring  
- Extensive test coverage confirms compatibility