### PR TITLE
fix: correct module import paths in reporter modules

### DIFF
--- a/scripts/utils/lint_reporter.py
+++ b/scripts/utils/lint_reporter.py
@@ -11,9 +11,9 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from scripts.utils.path_config import PathConfig
-from scripts.utils.report_base import BaseReporter
-from scripts.utils.server_variables_markdown import ServerVariablesMarkdownHelper
+from path_config import PathConfig
+from report_base import BaseReporter
+from server_variables_markdown import ServerVariablesMarkdownHelper
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/utils/report_base.py
+++ b/scripts/utils/report_base.py
@@ -13,7 +13,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from scripts.utils.path_config import PathConfig
+from path_config import PathConfig
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/utils/server_variables_markdown.py
+++ b/scripts/utils/server_variables_markdown.py
@@ -13,7 +13,7 @@ from typing import Any
 
 import yaml
 
-from scripts.utils.report_base import BaseReporter
+from report_base import BaseReporter
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/utils/validation_reporter.py
+++ b/scripts/utils/validation_reporter.py
@@ -11,9 +11,9 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from scripts.utils.path_config import PathConfig
-from scripts.utils.report_base import BaseReporter
-from scripts.utils.server_variables_markdown import ServerVariablesMarkdownHelper
+from path_config import PathConfig
+from report_base import BaseReporter
+from server_variables_markdown import ServerVariablesMarkdownHelper
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Fixes ModuleNotFoundError in CI/CD by changing imports from 'from scripts.utils.X' to 'from X' to match sys.path.insert() pattern. Tested locally. Fixes workflow run 21011738538.