### PR TITLE
test: update extension prefix and cache validation tests

### DIFF
--- a/tests/test_operation_metadata_enricher.py
+++ b/tests/test_operation_metadata_enricher.py
@@ -55,7 +55,7 @@ class TestOperationMetadataEnricherBasics:
         """Test enricher initializes with default config."""
         enricher = OperationMetadataEnricher()
         assert len(enricher.danger_levels) > 0
-        assert enricher.extension_prefix == "x-ves"
+        assert enricher.extension_prefix == "x-f5xc"
 
     def test_config_loading_missing_file(self):
         """Test enricher loads defaults when config file missing."""
@@ -311,20 +311,20 @@ class TestSpecEnrichment:
 
         # Check GET operation enriched
         list_op = result["paths"]["/api/config/namespaces/{namespace}/http_loadbalancers"]["get"]
-        assert "x-ves-danger-level" in list_op
-        assert list_op["x-ves-danger-level"] == "low"
+        assert "x-f5xc-danger-level" in list_op
+        assert list_op["x-f5xc-danger-level"] == "low"
 
         # Check DELETE operation enriched
         delete_op = result["paths"]["/api/config/namespaces/{namespace}/http_loadbalancers/{name}"][
             "delete"
         ]
-        assert "x-ves-danger-level" in delete_op
-        assert delete_op["x-ves-danger-level"] == "high"
-        assert delete_op.get("x-ves-confirmation-required") is True
+        assert "x-f5xc-danger-level" in delete_op
+        assert delete_op["x-f5xc-danger-level"] == "high"
+        assert delete_op.get("x-f5xc-confirmation-required") is True
 
         # Check POST operation has required fields
         create_op = result["paths"]["/api/config/namespaces/{namespace}/http_loadbalancers"]["post"]
-        assert "x-ves-required-fields" in create_op
+        assert "x-f5xc-required-fields" in create_op
 
     def test_stats_updated(self, enricher, simple_spec):
         """Test stats are updated after enrichment."""

--- a/tests/test_regex_precompilation.py
+++ b/tests/test_regex_precompilation.py
@@ -141,6 +141,7 @@ class TestValidatePatterns:
 
     def test_should_skip_endpoint_caching(self):
         """Verify endpoint skipping uses cached patterns."""
+        from scripts import validate
         from scripts.validate import should_skip_endpoint
 
         config = {
@@ -160,8 +161,9 @@ class TestValidatePatterns:
         should_skip2, reason2 = should_skip_endpoint(endpoint2, config)
         assert not should_skip2
 
-        # Verify cache was created
-        assert hasattr(should_skip_endpoint, "_skip_cache")
+        # Verify module-level caches exist (implementation uses module-level caching)
+        assert hasattr(validate, "_skip_patterns_cache")
+        assert hasattr(validate, "_include_patterns_cache")
 
     def test_resolve_path_parameters_with_precompiled(self):
         """Verify path parameter resolution uses precompiled pattern."""


### PR DESCRIPTION
Update test assertions to reflect rebranding from x-ves to x-f5xc extension prefix and correct module-level cache validation logic.

## Changes
- test_operation_metadata_enricher.py: Update 8 extension prefix assertions (x-ves → x-f5xc)
- test_regex_precompilation.py: Fix cache validation to check module-level caches

## Reason
- Consistency with codebase rebranding to F5 XC
- Correct test implementation to match actual caching behavior

Closes #413