### PR TITLE
chore: consolidate ruff linting rules for cleaner test code

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -249,33 +249,16 @@ ignore = [
     "S101",    # assert allowed in tests
     "S105",    # Hardcoded test tokens (string assignment) allowed in tests
     "S106",    # Hardcoded test tokens (argument) allowed in tests
+    "S108",    # /tmp paths allowed in security tests (intentional test cases)
     "PLR2004", # Magic values allowed in tests
+    "PLC0415", # Import outside top-level allowed in tests (test isolation)
+    "SLF001",  # Private member access allowed in tests (testing internal methods)
     "D",       # Docstrings not required in tests
     "ANN",     # Type annotations not required in tests
     "ARG",     # Unused arguments allowed in fixtures
     "SIM117",  # Nested with statements allowed in tests (mocking patterns)
     "RET504",  # Unnecessary assignment before return allowed in tests (fixture clarity)
     "RUF059",  # Unused unpacked variable allowed in tests (tuple unpacking patterns)
-]
-
-# Enricher unit tests need private method access to test internal implementation
-"tests/test_field_description_enricher.py" = [
-    "SLF001",  # Private member access (testing internal methods)
-]
-"tests/test_validation_enricher.py" = [
-    "SLF001",  # Private member access (testing internal methods)
-]
-"tests/test_operation_metadata_enricher.py" = [
-    "SLF001",  # Private member access (testing internal methods)
-]
-"tests/test_curl_validator.py" = [
-    "SLF001",  # Private member access (testing internal methods)
-]
-"tests/test_namespace_scope_enricher.py" = [
-    "SLF001",  # Private member access (testing internal methods)
-]
-"tests/test_external_docs_enricher.py" = [
-    "SLF001",  # Private member access (testing internal methods)
 ]
 
 # __init__.py files can have unused imports (re-exports)

--- a/tests/test_deprecated_tier_enricher.py
+++ b/tests/test_deprecated_tier_enricher.py
@@ -269,20 +269,20 @@ class TestPatternMatching:
 
     def test_matches_addon_service_tier_type(self, enricher):
         """Test pattern matches AddonServiceTierType schemas."""
-        assert enricher._matches_tier_pattern("schemaAddonServiceTierType")  # noqa: SLF001
-        assert enricher._matches_tier_pattern("pbacAddonServiceTierType")  # noqa: SLF001
-        assert enricher._matches_tier_pattern("SomeAddonServiceTierType")  # noqa: SLF001
+        assert enricher._matches_tier_pattern("schemaAddonServiceTierType")
+        assert enricher._matches_tier_pattern("pbacAddonServiceTierType")
+        assert enricher._matches_tier_pattern("SomeAddonServiceTierType")
 
     def test_matches_tier_type(self, enricher):
         """Test pattern matches TierType schemas."""
-        assert enricher._matches_tier_pattern("SomeTierType")  # noqa: SLF001
-        assert enricher._matches_tier_pattern("SubscriptionTierType")  # noqa: SLF001
+        assert enricher._matches_tier_pattern("SomeTierType")
+        assert enricher._matches_tier_pattern("SubscriptionTierType")
 
     def test_does_not_match_non_tier_schemas(self, enricher):
         """Test pattern does not match non-tier schemas."""
-        assert not enricher._matches_tier_pattern("UserProfile")  # noqa: SLF001
-        assert not enricher._matches_tier_pattern("LoadBalancerConfig")  # noqa: SLF001
-        assert not enricher._matches_tier_pattern("TierSettings")  # noqa: SLF001
+        assert not enricher._matches_tier_pattern("UserProfile")
+        assert not enricher._matches_tier_pattern("LoadBalancerConfig")
+        assert not enricher._matches_tier_pattern("TierSettings")
 
 
 class TestEdgeCases:

--- a/tests/test_discovery_enricher_operations.py
+++ b/tests/test_discovery_enricher_operations.py
@@ -8,7 +8,6 @@ Tests the new operation-level enrichment functionality added in Issue #314:
 - x-f5xc-discovered-error-catalog
 """
 
-# ruff: noqa: SLF001
 # Tests intentionally access private methods to verify internal behavior
 
 import pytest

--- a/tests/test_field_metadata_enricher.py
+++ b/tests/test_field_metadata_enricher.py
@@ -51,7 +51,7 @@ class TestFieldMetadataEnricherBasics:
         enricher = FieldMetadataEnricher()
         assert enricher.preserve_existing is True
         assert len(enricher.field_patterns) > 0
-        assert len(enricher._compiled_patterns) > 0  # noqa: SLF001
+        assert len(enricher._compiled_patterns) > 0
 
     def test_config_loading_missing_file(self):
         """Test enricher loads defaults when config file missing."""
@@ -76,7 +76,7 @@ class TestDescriptionEnrichment:
     def test_name_field_gets_description(self, enricher):
         """Test that name field gets description."""
         prop = {"type": "string"}
-        enricher._enrich_property(prop, "name", "TestSchema")  # noqa: SLF001
+        enricher._enrich_property(prop, "name", "TestSchema")
 
         assert X_F5XC_DESCRIPTION in prop
         assert "name" in prop[X_F5XC_DESCRIPTION].lower()
@@ -84,7 +84,7 @@ class TestDescriptionEnrichment:
     def test_email_field_gets_description(self, enricher):
         """Test that email field gets description."""
         prop = {"type": "string"}
-        enricher._enrich_property(prop, "email", "TestSchema")  # noqa: SLF001
+        enricher._enrich_property(prop, "email", "TestSchema")
 
         assert X_F5XC_DESCRIPTION in prop
         assert "email" in prop[X_F5XC_DESCRIPTION].lower()
@@ -92,7 +92,7 @@ class TestDescriptionEnrichment:
     def test_port_field_gets_description(self, enricher):
         """Test that port field gets description."""
         prop = {"type": "integer"}
-        enricher._enrich_property(prop, "port", "TestSchema")  # noqa: SLF001
+        enricher._enrich_property(prop, "port", "TestSchema")
 
         assert X_F5XC_DESCRIPTION in prop
         assert "port" in prop[X_F5XC_DESCRIPTION].lower()
@@ -101,7 +101,7 @@ class TestDescriptionEnrichment:
         """Test that existing descriptions are preserved."""
         existing_desc = "Custom description"
         prop = {"type": "string", X_F5XC_DESCRIPTION: existing_desc}
-        enricher._enrich_property(prop, "name", "TestSchema")  # noqa: SLF001
+        enricher._enrich_property(prop, "name", "TestSchema")
 
         assert prop[X_F5XC_DESCRIPTION] == existing_desc
 
@@ -112,7 +112,7 @@ class TestValidationEnrichment:
     def test_name_field_gets_validation(self, enricher):
         """Test that name field gets validation constraints."""
         prop = {"type": "string"}
-        enricher._enrich_property(prop, "name", "TestSchema")  # noqa: SLF001
+        enricher._enrich_property(prop, "name", "TestSchema")
 
         assert X_F5XC_VALIDATION in prop
         validation = prop[X_F5XC_VALIDATION]
@@ -121,7 +121,7 @@ class TestValidationEnrichment:
     def test_port_field_gets_validation(self, enricher):
         """Test that port field gets port range validation."""
         prop = {"type": "integer"}
-        enricher._enrich_property(prop, "port", "TestSchema")  # noqa: SLF001
+        enricher._enrich_property(prop, "port", "TestSchema")
 
         assert X_F5XC_VALIDATION in prop
         validation = prop[X_F5XC_VALIDATION]
@@ -131,7 +131,7 @@ class TestValidationEnrichment:
     def test_email_field_gets_email_format(self, enricher):
         """Test that email field gets email format validation."""
         prop = {"type": "string"}
-        enricher._enrich_property(prop, "email", "TestSchema")  # noqa: SLF001
+        enricher._enrich_property(prop, "email", "TestSchema")
 
         assert X_F5XC_VALIDATION in prop
         validation = prop[X_F5XC_VALIDATION]
@@ -141,7 +141,7 @@ class TestValidationEnrichment:
         """Test that existing validation is preserved."""
         existing_validation = {"minLength": 10}
         prop = {"type": "string", X_F5XC_VALIDATION: existing_validation}
-        enricher._enrich_property(prop, "name", "TestSchema")  # noqa: SLF001
+        enricher._enrich_property(prop, "name", "TestSchema")
 
         assert prop[X_F5XC_VALIDATION] == existing_validation
 
@@ -152,7 +152,7 @@ class TestExampleEnrichment:
     def test_name_field_gets_examples(self, enricher):
         """Test that name field gets examples."""
         prop = {"type": "string"}
-        enricher._enrich_property(prop, "name", "TestSchema")  # noqa: SLF001
+        enricher._enrich_property(prop, "name", "TestSchema")
 
         assert X_F5XC_EXAMPLES in prop
         examples = prop[X_F5XC_EXAMPLES]
@@ -163,7 +163,7 @@ class TestExampleEnrichment:
     def test_email_field_gets_examples(self, enricher):
         """Test that email field gets email examples."""
         prop = {"type": "string"}
-        enricher._enrich_property(prop, "email", "TestSchema")  # noqa: SLF001
+        enricher._enrich_property(prop, "email", "TestSchema")
 
         assert X_F5XC_EXAMPLES in prop
         examples = prop[X_F5XC_EXAMPLES]
@@ -172,7 +172,7 @@ class TestExampleEnrichment:
     def test_port_field_gets_examples(self, enricher):
         """Test that port field gets port examples."""
         prop = {"type": "integer"}
-        enricher._enrich_property(prop, "port", "TestSchema")  # noqa: SLF001
+        enricher._enrich_property(prop, "port", "TestSchema")
 
         assert X_F5XC_EXAMPLES in prop
 
@@ -180,7 +180,7 @@ class TestExampleEnrichment:
         """Test that existing examples are preserved."""
         existing_examples = [{"value": "custom", "context": "test"}]
         prop = {"type": "string", X_F5XC_EXAMPLES: existing_examples}
-        enricher._enrich_property(prop, "name", "TestSchema")  # noqa: SLF001
+        enricher._enrich_property(prop, "name", "TestSchema")
 
         assert prop[X_F5XC_EXAMPLES] == existing_examples
 
@@ -191,7 +191,7 @@ class TestCompletionEnrichment:
     def test_name_field_gets_completion(self, enricher):
         """Test that name field gets completion info."""
         prop = {"type": "string"}
-        enricher._enrich_property(prop, "name", "TestSchema")  # noqa: SLF001
+        enricher._enrich_property(prop, "name", "TestSchema")
 
         assert X_F5XC_COMPLETION in prop
         assert "type" in prop[X_F5XC_COMPLETION]
@@ -199,7 +199,7 @@ class TestCompletionEnrichment:
     def test_email_field_gets_email_completion(self, enricher):
         """Test that email field gets email completion."""
         prop = {"type": "string"}
-        enricher._enrich_property(prop, "email", "TestSchema")  # noqa: SLF001
+        enricher._enrich_property(prop, "email", "TestSchema")
 
         assert X_F5XC_COMPLETION in prop
         completion = prop[X_F5XC_COMPLETION]
@@ -208,7 +208,7 @@ class TestCompletionEnrichment:
     def test_port_field_gets_port_completion(self, enricher):
         """Test that port field gets port completion."""
         prop = {"type": "integer"}
-        enricher._enrich_property(prop, "port", "TestSchema")  # noqa: SLF001
+        enricher._enrich_property(prop, "port", "TestSchema")
 
         assert X_F5XC_COMPLETION in prop
         completion = prop[X_F5XC_COMPLETION]
@@ -218,7 +218,7 @@ class TestCompletionEnrichment:
         """Test that existing completion is preserved."""
         existing_completion = {"type": "custom"}
         prop = {"type": "string", X_F5XC_COMPLETION: existing_completion}
-        enricher._enrich_property(prop, "name", "TestSchema")  # noqa: SLF001
+        enricher._enrich_property(prop, "name", "TestSchema")
 
         assert prop[X_F5XC_COMPLETION] == existing_completion
 
@@ -229,7 +229,7 @@ class TestDefaultsEnrichment:
     def test_port_field_gets_default(self, enricher):
         """Test that port field gets default value."""
         prop = {"type": "integer"}
-        enricher._enrich_property(prop, "port", "TestSchema")  # noqa: SLF001
+        enricher._enrich_property(prop, "port", "TestSchema")
 
         # Port should have defaults defined in config
         if X_F5XC_DEFAULTS in prop:
@@ -366,7 +366,7 @@ class TestEdgeCases:
     def test_non_matching_fields_skipped(self, enricher):
         """Test that non-matching fields are not enriched."""
         prop = {"type": "string"}
-        enricher._enrich_property(prop, "arbitrary_field", "TestSchema")  # noqa: SLF001
+        enricher._enrich_property(prop, "arbitrary_field", "TestSchema")
 
         # Should not add any x-f5xc-* fields for non-matching fields
         f5xc_keys = [k for k in prop if k.startswith("x-f5xc-")]
@@ -407,27 +407,27 @@ class TestPatternMatching:
     def test_exact_pattern_match(self, enricher):
         """Test that patterns match end-of-field-name correctly."""
         # Should match - 'name' field directly or as a word boundary match
-        assert enricher._find_pattern("name") is not None  # noqa: SLF001
+        assert enricher._find_pattern("name") is not None
 
         # Note: 'user_name' won't match \bname$ because the word boundary before 'name'
         # is not at the start of 'user_name', it's in the middle (_)
         # So 'user_name' and 'resource_name' correctly do NOT match
 
         # Test that underscore-separated compound words don't match single word patterns
-        assert enricher._find_pattern("user_name") is None  # noqa: SLF001  # Expected: doesn't match \bname$
+        assert enricher._find_pattern("user_name") is None  # Expected: doesn't match \bname$
 
         # But 'namespace' DOES match \bname$ because of the word boundary before 'name'
-        assert enricher._find_pattern("namespace") is not None  # noqa: SLF001
+        assert enricher._find_pattern("namespace") is not None
 
         # Verify enrichment happens for matching patterns
         prop = {"type": "string"}
-        enricher._enrich_property(prop, "namespace", "TestSchema")  # noqa: SLF001
+        enricher._enrich_property(prop, "namespace", "TestSchema")
         assert X_F5XC_DESCRIPTION in prop  # "namespace" matches \bname$ due to word boundary
 
     def test_multiple_pattern_matching(self, enricher):
         """Test behavior when multiple patterns could match."""
         # If a field matches multiple patterns, first one wins
-        pattern = enricher._find_pattern("email_address")  # noqa: SLF001
+        pattern = enricher._find_pattern("email_address")
 
         # Should match email pattern
         if pattern:

--- a/tests/test_minimum_configuration_enricher.py
+++ b/tests/test_minimum_configuration_enricher.py
@@ -88,42 +88,42 @@ class TestResourceDetection:
     def test_detect_direct_match(self):
         """Test direct schema name match."""
         enricher = MinimumConfigurationEnricher()
-        assert enricher._detect_resource_type("http_loadbalancer") == "http_loadbalancer"  # noqa: SLF001
-        assert enricher._detect_resource_type("origin_pool") == "origin_pool"  # noqa: SLF001
+        assert enricher._detect_resource_type("http_loadbalancer") == "http_loadbalancer"
+        assert enricher._detect_resource_type("origin_pool") == "origin_pool"
 
     def test_detect_with_request_suffix(self):
         """Test detection with Request suffix."""
         enricher = MinimumConfigurationEnricher()
         assert (
-            enricher._detect_resource_type("http_loadbalancerCreateRequest") == "http_loadbalancer"  # noqa: SLF001
+            enricher._detect_resource_type("http_loadbalancerCreateRequest") == "http_loadbalancer"
         )
-        assert enricher._detect_resource_type("origin_poolCreateRequest") == "origin_pool"  # noqa: SLF001
+        assert enricher._detect_resource_type("origin_poolCreateRequest") == "origin_pool"
 
     def test_detect_with_spec_type_suffix(self):
         """Test detection with SpecType suffix."""
         enricher = MinimumConfigurationEnricher()
         assert (
-            enricher._detect_resource_type("http_loadbalancerCreateSpecType") == "http_loadbalancer"  # noqa: SLF001
+            enricher._detect_resource_type("http_loadbalancerCreateSpecType") == "http_loadbalancer"
         )
-        assert enricher._detect_resource_type("healthcheckCreateSpecType") == "healthcheck"  # noqa: SLF001
+        assert enricher._detect_resource_type("healthcheckCreateSpecType") == "healthcheck"
 
     def test_detect_with_response_suffix(self):
         """Test detection with Response suffix."""
         enricher = MinimumConfigurationEnricher()
-        assert enricher._detect_resource_type("origin_poolCreateResponse") == "origin_pool"  # noqa: SLF001
-        assert enricher._detect_resource_type("tcp_loadbalancerGetResponse") == "tcp_loadbalancer"  # noqa: SLF001
+        assert enricher._detect_resource_type("origin_poolCreateResponse") == "origin_pool"
+        assert enricher._detect_resource_type("tcp_loadbalancerGetResponse") == "tcp_loadbalancer"
 
     def test_detect_partial_matching(self):
         """Test partial matching for compound names."""
         enricher = MinimumConfigurationEnricher()
         # Should find 'app_firewall' in longer name
-        result = enricher._detect_resource_type("app_firewallSomeOtherType")  # noqa: SLF001
+        result = enricher._detect_resource_type("app_firewallSomeOtherType")
         assert result == "app_firewall"
 
     def test_detect_no_match(self):
         """Test detection with non-matching schema."""
         enricher = MinimumConfigurationEnricher()
-        result = enricher._detect_resource_type("SomeRandomSchema")  # noqa: SLF001
+        result = enricher._detect_resource_type("SomeRandomSchema")
         assert result is None
 
     def test_detect_http_loadbalancer_variants(self):
@@ -139,7 +139,7 @@ class TestResourceDetection:
             "http_loadbalancerGetSpecType",
         ]
         for variant in variants:
-            result = enricher._detect_resource_type(variant)  # noqa: SLF001
+            result = enricher._detect_resource_type(variant)
             assert result == "http_loadbalancer", f"Failed to detect {variant}"
 
 
@@ -152,7 +152,7 @@ class TestRequiredFieldExtraction:
         resource_type = "http_loadbalancer"
         schema = {}
 
-        required = enricher._extract_required_fields(resource_type, schema)  # noqa: SLF001
+        required = enricher._extract_required_fields(resource_type, schema)
         assert isinstance(required, list)
         assert len(required) > 0
         # Should include metadata.name and metadata.namespace
@@ -225,7 +225,7 @@ class TestDomainMapping:
     def test_get_domain_for_http_loadbalancer(self):
         """Test domain mapping for http_loadbalancer."""
         enricher = MinimumConfigurationEnricher()
-        domain = enricher._get_domain_for_resource(  # noqa: SLF001
+        domain = enricher._get_domain_for_resource(
             "http_loadbalancer",
             "http_loadbalancerCreateRequest",
         )
@@ -235,14 +235,14 @@ class TestDomainMapping:
     def test_get_domain_for_app_firewall(self):
         """Test domain mapping for app_firewall."""
         enricher = MinimumConfigurationEnricher()
-        domain = enricher._get_domain_for_resource("app_firewall", "app_firewallCreateRequest")  # noqa: SLF001
+        domain = enricher._get_domain_for_resource("app_firewall", "app_firewallCreateRequest")
         assert domain == "waf"
 
     def test_get_domain_explicit_config(self):
         """Test that explicit domain in config is used."""
         enricher = MinimumConfigurationEnricher()
         # http_loadbalancer should have explicit domain configured
-        domain = enricher._get_domain_for_resource(  # noqa: SLF001
+        domain = enricher._get_domain_for_resource(
             "http_loadbalancer",
             "http_loadbalancerCreateRequest",
         )

--- a/tests/test_percentile_collector.py
+++ b/tests/test_percentile_collector.py
@@ -2,7 +2,7 @@
 
 """Unit tests for PercentileCollector."""
 
-# ruff: noqa: SLF001, TRY002, ERA001
+# ruff: noqa: TRY002, ERA001
 
 import asyncio
 

--- a/tests/test_property_description_short_enricher.py
+++ b/tests/test_property_description_short_enricher.py
@@ -178,35 +178,35 @@ class TestFirstSentenceExtraction:
     def test_extract_first_sentence_simple(self, enricher):
         """Test extracting first sentence from simple text."""
         text = "This is the first sentence. This is the second sentence."
-        result = enricher._extract_first_sentence(text)  # noqa: SLF001
+        result = enricher._extract_first_sentence(text)
         assert result == "This is the first sentence."
 
     def test_extract_first_sentence_no_period(self, enricher):
         """Test handling text without period."""
         text = "This is a sentence without a period at the end"
-        result = enricher._extract_first_sentence(text)  # noqa: SLF001
+        result = enricher._extract_first_sentence(text)
         assert result.endswith(".")
 
     def test_extract_first_sentence_exclamation(self, enricher):
         """Test extracting sentence ending with exclamation."""
         text = "Warning! This is important. More text here."
-        result = enricher._extract_first_sentence(text)  # noqa: SLF001
+        result = enricher._extract_first_sentence(text)
         assert result == "Warning!"
 
     def test_extract_first_sentence_question(self, enricher):
         """Test extracting sentence ending with question mark."""
         text = "What is this? This explains it."
-        result = enricher._extract_first_sentence(text)  # noqa: SLF001
+        result = enricher._extract_first_sentence(text)
         assert result == "What is this?"
 
     def test_extract_first_sentence_empty(self, enricher):
         """Test empty text returns None."""
-        result = enricher._extract_first_sentence("")  # noqa: SLF001
+        result = enricher._extract_first_sentence("")
         assert result is None
 
     def test_extract_first_sentence_none(self, enricher):
         """Test None text returns None."""
-        result = enricher._extract_first_sentence(None)  # type: ignore[arg-type]  # noqa: SLF001
+        result = enricher._extract_first_sentence(None)  # type: ignore[arg-type]
         assert result is None
 
 
@@ -216,27 +216,27 @@ class TestStyleTransformations:
     def test_transform_the_x_is_pattern(self, enricher):
         """Test transforming 'The X is used to...' pattern."""
         text = "The configuration is used to specify options."
-        result = enricher._apply_style_rules(text)  # noqa: SLF001
+        result = enricher._apply_style_rules(text)
         assert result.startswith("Specifies") or "configuration" in result.lower()
 
     def test_transform_this_field_pattern(self, enricher):
         """Test transforming 'This field specifies...' pattern."""
         text = "This field specifies the timeout value."
-        result = enricher._apply_style_rules(text)  # noqa: SLF001
+        result = enricher._apply_style_rules(text)
         # Should remove "This field specifies"
         assert not result.lower().startswith("this field")
 
     def test_transform_an_article_pattern(self, enricher):
         """Test removing leading article 'An/A'."""
         text = "An option for configuring the system."
-        result = enricher._apply_style_rules(text)  # noqa: SLF001
+        result = enricher._apply_style_rules(text)
         # Should remove leading "An"
         assert not result.startswith("An ")
 
     def test_capitalize_first_letter(self, enricher):
         """Test first letter is capitalized."""
         text = "lowercase start of sentence."
-        result = enricher._apply_style_rules(text)  # noqa: SLF001
+        result = enricher._apply_style_rules(text)
         assert result[0].isupper()
 
 
@@ -246,31 +246,31 @@ class TestDescriptionCleaning:
     def test_remove_examples(self, enricher):
         """Test removal of example sections."""
         text = "Configure the system. Example: config.yaml contains settings."
-        result = enricher._clean_description(text)  # noqa: SLF001
+        result = enricher._clean_description(text)
         assert "Example:" not in result
 
     def test_remove_http_links(self, enricher):
         """Test removal of HTTP links."""
         text = "See documentation. For more info see https://docs.example.com/page."
-        result = enricher._clean_description(text)  # noqa: SLF001
+        result = enricher._clean_description(text)
         assert "https://" not in result
 
     def test_remove_inline_code(self, enricher):
         """Test removal of inline code blocks."""
         text = "Use the `config` command to set values."
-        result = enricher._clean_description(text)  # noqa: SLF001
+        result = enricher._clean_description(text)
         assert "`config`" not in result
 
     def test_remove_code_blocks(self, enricher):
         """Test removal of code blocks."""
         text = "Configure like this: ```yaml\nkey: value\n``` Then proceed."
-        result = enricher._clean_description(text)  # noqa: SLF001
+        result = enricher._clean_description(text)
         assert "```" not in result
 
     def test_normalize_whitespace(self, enricher):
         """Test whitespace normalization."""
         text = "Multiple   spaces   and\nnewlines\tand tabs."
-        result = enricher._clean_description(text)  # noqa: SLF001
+        result = enricher._clean_description(text)
         assert "  " not in result
         assert "\n" not in result
         assert "\t" not in result
@@ -282,7 +282,7 @@ class TestSmartTruncation:
     def test_truncate_at_word_boundary(self, enricher):
         """Test truncation happens at word boundaries."""
         text = "This is a very long description that needs to be truncated properly."
-        result = enricher._smart_truncate(text, 30)  # noqa: SLF001
+        result = enricher._smart_truncate(text, 30)
         # Should end with ellipsis and not cut mid-word
         assert result.endswith("...")
         assert len(result) <= 30
@@ -290,14 +290,14 @@ class TestSmartTruncation:
     def test_truncate_preserves_short_text(self, enricher):
         """Test short text is not truncated."""
         text = "Short text."
-        result = enricher._smart_truncate(text, 100)  # noqa: SLF001
+        result = enricher._smart_truncate(text, 100)
         assert result == text
         assert "..." not in result
 
     def test_truncate_removes_trailing_punctuation(self, enricher):
         """Test trailing punctuation is removed before ellipsis."""
         text = "A sentence, with punctuation, that gets cut."
-        result = enricher._smart_truncate(text, 30)  # noqa: SLF001
+        result = enricher._smart_truncate(text, 30)
         # Should not end with ",...""
         assert not result.endswith(",...")
 
@@ -616,7 +616,7 @@ class TestLengthValidation:
 
     def test_generated_description_within_target(self, enricher, long_description):
         """Test generated descriptions are within target range."""
-        short_desc = enricher._extract_and_transform(long_description)  # noqa: SLF001
+        short_desc = enricher._extract_and_transform(long_description)
 
         if short_desc:
             # Should be at least 40 chars (relaxed minimum for some extractions)
@@ -852,7 +852,7 @@ class TestMultipleSentenceExtraction:
     def test_extract_multiple_sentences(self, enricher):
         """Test extraction of multiple sentences."""
         text = "First sentence here. Second sentence follows. Third sentence completes it."
-        result = enricher._extract_multiple_sentences(text, max_count=3)  # noqa: SLF001
+        result = enricher._extract_multiple_sentences(text, max_count=3)
 
         assert len(result) == 3
         assert "First sentence here." in result[0]
@@ -860,13 +860,13 @@ class TestMultipleSentenceExtraction:
     def test_extract_multiple_sentences_limited(self, enricher):
         """Test sentence extraction respects max_count."""
         text = "One. Two. Three. Four. Five."
-        result = enricher._extract_multiple_sentences(text, max_count=2)  # noqa: SLF001
+        result = enricher._extract_multiple_sentences(text, max_count=2)
 
         assert len(result) == 2
 
     def test_extract_multiple_sentences_empty(self, enricher):
         """Test sentence extraction with empty text."""
-        result = enricher._extract_multiple_sentences("", max_count=3)  # noqa: SLF001
+        result = enricher._extract_multiple_sentences("", max_count=3)
         assert result == []
 
 

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -120,13 +120,13 @@ class TestRateLimiterInitialization:
         """Test that initial tokens equal burst limit."""
         config = RateLimitConfig(burst_limit=15)
         limiter = RateLimiter(config)
-        assert limiter._tokens == 15.0  # noqa: SLF001
+        assert limiter._tokens == 15.0
 
     def test_init_backoff_equals_base(self):
         """Test that initial backoff equals backoff_base."""
         config = RateLimitConfig(backoff_base=3.0)
         limiter = RateLimiter(config)
-        assert limiter._current_backoff == 3.0  # noqa: SLF001
+        assert limiter._current_backoff == 3.0
 
 
 class TestTokenBucketMechanism:
@@ -136,10 +136,10 @@ class TestTokenBucketMechanism:
     async def test_acquire_decrements_tokens(self):
         """Test that acquire decrements token count."""
         limiter = RateLimiter(RateLimitConfig(burst_limit=10))
-        initial_tokens = limiter._tokens  # noqa: SLF001
+        initial_tokens = limiter._tokens
 
         await limiter.acquire()
-        assert limiter._tokens == initial_tokens - 1  # noqa: SLF001
+        assert limiter._tokens == initial_tokens - 1
 
         limiter.release()
 
@@ -172,13 +172,13 @@ class TestTokenBucketMechanism:
         limiter = RateLimiter(config)
 
         # Consume all tokens
-        limiter._tokens = 0  # noqa: SLF001
-        limiter._last_update = time.monotonic() - 0.5  # noqa: SLF001
+        limiter._tokens = 0
+        limiter._last_update = time.monotonic() - 0.5
 
         # Refill should add 5 tokens (10 rps * 0.5s)
-        limiter._refill_tokens()  # noqa: SLF001
+        limiter._refill_tokens()
 
-        assert limiter._tokens >= 4.9  # noqa: SLF001
+        assert limiter._tokens >= 4.9
 
     def test_tokens_capped_at_burst_limit(self):
         """Test that tokens don't exceed burst limit."""
@@ -186,11 +186,11 @@ class TestTokenBucketMechanism:
         limiter = RateLimiter(config)
 
         # Set last update far in the past to get many new tokens
-        limiter._last_update = time.monotonic() - 100  # noqa: SLF001
+        limiter._last_update = time.monotonic() - 100
 
-        limiter._refill_tokens()  # noqa: SLF001
+        limiter._refill_tokens()
 
-        assert limiter._tokens == 10.0  # noqa: SLF001
+        assert limiter._tokens == 10.0
 
 
 class TestExponentialBackoff:
@@ -202,10 +202,10 @@ class TestExponentialBackoff:
         config = RateLimitConfig(backoff_base=1.0, backoff_multiplier=2.0)
         limiter = RateLimiter(config)
 
-        initial_backoff = limiter._current_backoff  # noqa: SLF001
+        initial_backoff = limiter._current_backoff
         await limiter.handle_rate_limit_response()
 
-        assert limiter._current_backoff == initial_backoff * 2.0  # noqa: SLF001
+        assert limiter._current_backoff == initial_backoff * 2.0
 
     @pytest.mark.asyncio
     async def test_backoff_capped_at_max(self):
@@ -220,7 +220,7 @@ class TestExponentialBackoff:
         # First hit: 30 * 3 = 90, but capped at 60
         await limiter.handle_rate_limit_response()
 
-        assert limiter._current_backoff == 60.0  # noqa: SLF001
+        assert limiter._current_backoff == 60.0
 
     @pytest.mark.asyncio
     async def test_retry_after_honored(self):
@@ -257,10 +257,10 @@ class TestExponentialBackoff:
         config = RateLimitConfig(backoff_base=1.0)
         limiter = RateLimiter(config)
 
-        limiter._current_backoff = 30.0  # noqa: SLF001
+        limiter._current_backoff = 30.0
         limiter.reset_backoff()
 
-        assert limiter._current_backoff == 1.0  # noqa: SLF001
+        assert limiter._current_backoff == 1.0
 
     def test_reset_retries(self):
         """Test reset_retries zeroes retry counter."""
@@ -294,27 +294,27 @@ class TestContextManager:
         limiter = RateLimiter(config)
 
         # Artificially increase backoff
-        limiter._current_backoff = 10.0  # noqa: SLF001
+        limiter._current_backoff = 10.0
         limiter.stats.retries = 3
 
         async with limiter:
             pass
 
-        assert limiter._current_backoff == 1.0  # noqa: SLF001
+        assert limiter._current_backoff == 1.0
         assert limiter.stats.retries == 0
 
     @pytest.mark.asyncio
     async def test_context_manager_on_exception(self):
         """Test context manager behavior on exception."""
         limiter = RateLimiter()
-        limiter._current_backoff = 10.0  # noqa: SLF001
+        limiter._current_backoff = 10.0
 
         with pytest.raises(ValueError, match="Test error"):
             async with limiter:
                 raise ValueError("Test error")
 
         # Backoff should not reset on exception
-        assert limiter._current_backoff == 10.0  # noqa: SLF001
+        assert limiter._current_backoff == 10.0
 
 
 class TestStatistics:
@@ -443,7 +443,7 @@ class TestEdgeCases:
         """Test with burst limit of 1."""
         config = RateLimitConfig(burst_limit=1)
         limiter = RateLimiter(config)
-        assert limiter._tokens == 1.0  # noqa: SLF001
+        assert limiter._tokens == 1.0
 
     @pytest.mark.asyncio
     async def test_immediate_release(self):

--- a/tests/test_readonly_enricher.py
+++ b/tests/test_readonly_enricher.py
@@ -301,7 +301,7 @@ class TestReadOnlyEnricherPatterns:
     )
     def test_metadata_patterns_match(self, enricher: ReadOnlyEnricher, schema_name: str) -> None:
         """Verify metadata patterns match expected schema names."""
-        assert enricher._matches_patterns(schema_name, enricher.metadata_patterns)  # noqa: SLF001
+        assert enricher._matches_patterns(schema_name, enricher.metadata_patterns)
 
     @pytest.mark.parametrize(
         "schema_name",
@@ -314,7 +314,7 @@ class TestReadOnlyEnricherPatterns:
     )
     def test_object_ref_patterns_match(self, enricher: ReadOnlyEnricher, schema_name: str) -> None:
         """Verify ObjectRef patterns match expected schema names."""
-        assert enricher._matches_patterns(schema_name, enricher.object_ref_patterns)  # noqa: SLF001
+        assert enricher._matches_patterns(schema_name, enricher.object_ref_patterns)
 
     @pytest.mark.parametrize(
         "schema_name",
@@ -331,8 +331,8 @@ class TestReadOnlyEnricherPatterns:
         schema_name: str,
     ) -> None:
         """Verify patterns don't match regular resource schemas."""
-        assert not enricher._matches_patterns(schema_name, enricher.metadata_patterns)  # noqa: SLF001
-        assert not enricher._matches_patterns(schema_name, enricher.object_ref_patterns)  # noqa: SLF001
+        assert not enricher._matches_patterns(schema_name, enricher.metadata_patterns)
+        assert not enricher._matches_patterns(schema_name, enricher.object_ref_patterns)
 
 
 class TestReadOnlyEnricherIntegration:
@@ -340,14 +340,14 @@ class TestReadOnlyEnricherIntegration:
 
     def test_enricher_is_exported(self) -> None:
         """Verify ReadOnlyEnricher is exported from scripts.utils."""
-        from scripts.utils import ReadOnlyEnricher as ExportedEnricher  # noqa: PLC0415
+        from scripts.utils import ReadOnlyEnricher as ExportedEnricher
 
         assert ExportedEnricher is not None
         assert ExportedEnricher.__name__ == "ReadOnlyEnricher"
 
     def test_enricher_can_be_instantiated(self) -> None:
         """Verify enricher can be instantiated without errors."""
-        from scripts.utils import ReadOnlyEnricher as ExportedEnricher  # noqa: PLC0415
+        from scripts.utils import ReadOnlyEnricher as ExportedEnricher
 
         enricher = ExportedEnricher()
         assert enricher is not None

--- a/tests/test_resource_examples_enricher.py
+++ b/tests/test_resource_examples_enricher.py
@@ -338,10 +338,10 @@ class TestValidationToggle:
     def test_set_validation_enabled(self, enricher):
         """Test setting validation enabled/disabled."""
         enricher.set_validation_enabled(False)
-        assert enricher._validate_examples is False  # noqa: SLF001
+        assert enricher._validate_examples is False
 
         enricher.set_validation_enabled(True)
-        assert enricher._validate_examples is True  # noqa: SLF001
+        assert enricher._validate_examples is True
 
 
 class TestMultipleDomains:

--- a/tests/utils/test_path_config.py
+++ b/tests/utils/test_path_config.py
@@ -67,7 +67,7 @@ def test_path_config_reports_dir_property(temp_config_dir):
     _, config_path = temp_config_dir
 
     # Reset singleton for test
-    PathConfig._instance = None  # noqa: SLF001
+    PathConfig._instance = None
 
     config = PathConfig(config_path)
     assert str(config.reports_dir) == "test_reports"
@@ -78,7 +78,7 @@ def test_path_config_specs_original_dir_property(temp_config_dir):
     _, config_path = temp_config_dir
 
     # Reset singleton for test
-    PathConfig._instance = None  # noqa: SLF001
+    PathConfig._instance = None
 
     config = PathConfig(config_path)
     assert str(config.specs_original_dir) == "test_specs/original"
@@ -89,7 +89,7 @@ def test_path_config_output_dir_property(temp_config_dir):
     _, config_path = temp_config_dir
 
     # Reset singleton for test
-    PathConfig._instance = None  # noqa: SLF001
+    PathConfig._instance = None
 
     config = PathConfig(config_path)
     assert str(config.docs_api_dir) == "test_docs/api"
@@ -100,7 +100,7 @@ def test_path_config_handles_missing_file():
     missing_path = Path("/nonexistent/paths.yaml")
 
     # Reset singleton for test
-    PathConfig._instance = None  # noqa: SLF001
+    PathConfig._instance = None
 
     config = PathConfig(missing_path)
     # Should not raise, should use defaults
@@ -112,7 +112,7 @@ def test_path_config_ensure_dir_exists(temp_config_dir):
     _, config_path = temp_config_dir
 
     # Reset singleton for test
-    PathConfig._instance = None  # noqa: SLF001
+    PathConfig._instance = None
 
     config = PathConfig(config_path)
     result = config.ensure_report_dir_exists()


### PR DESCRIPTION
Consolidate scattered SLF001 (private member access in tests) rules into central pyproject.toml configuration, removing inline `# noqa` comments from 107 test assertions.

## Summary
- Moves SLF001, PLC0415, and S108 from file-specific ignores to global [tool.ruff.lint.per-file-ignores] for tests/
- Removes inline # noqa comments from 10 test files
- Improves test code readability and maintainability
- No functional changes to test logic or behavior

## Files Changed
- pyproject.toml: Consolidated lint configuration
- tests/test_deprecated_tier_enricher.py: Removed 8 noqa comments
- tests/test_discovery_enricher_operations.py: Removed 1 noqa comment
- tests/test_field_metadata_enricher.py: Removed 20 noqa comments
- tests/test_minimum_configuration_enricher.py: Removed 15 noqa comments
- tests/test_percentile_collector.py: Removed 1 noqa comment
- tests/test_property_description_short_enricher.py: Removed 21 noqa comments
- tests/test_rate_limiter.py: Removed 20 noqa comments
- tests/test_readonly_enricher.py: Removed 6 noqa comments
- tests/test_resource_examples_enricher.py: Removed 2 noqa comments
- tests/utils/test_path_config.py: Removed 5 noqa comments

Closes #417