### PR TITLE
fix: restore release creation for scheduled workflow runs

### DIFF
--- a/.github/workflows/sync-and-enrich.yml
+++ b/.github/workflows/sync-and-enrich.yml
@@ -68,6 +68,7 @@ jobs:
             set -e
 
             if [ $EXIT_CODE -eq 1 ]; then
+              echo "updated=true" >> "$GITHUB_OUTPUT"
               echo "Updates detected - will proceed with download"
               exit 0
             elif [ $EXIT_CODE -eq 0 ]; then


### PR DESCRIPTION
## Problem

Fixes critical workflow bug preventing releases since Jan 8, 2026 (7 days, 48 commits without release).

## Root Cause

Scheduled workflow runs execute `python -m scripts.download --check-only` which correctly detects updates (exit code 1), but the code at lines 70-72 never sets the `updated=true` output variable. This causes the `sync-and-enrich` job to be **SKIPPED** because the condition `needs.check-updates.outputs.has_updates == 'true'` fails.

## Evidence

- Latest release: v2.0.21 (Jan 8, 2026)
- Current .version file: 2.0.20 (hasn't bumped)
- Commits since Jan 8: 48 commits
- Workflow runs: 25+ showing "successful" but sync-and-enrich job SKIPPED

## Solution

Add single line at line 71:
```bash
echo "updated=true" >> "$GITHUB_OUTPUT"
```

This ensures scheduled runs properly set the output variable when updates are detected, allowing the sync-and-enrich job to run and create releases.

## Testing Plan

**IMPORTANT**: This PR should be tested with manual workflow dispatch BEFORE merging:

```bash
# After PR creation, test with manual dispatch
gh workflow run sync-and-enrich.yml --ref fix/workflow-scheduled-release-creation

# Watch execution
gh run watch

# Verify:
# 1. check-updates job sets updated=true output
# 2. sync-and-enrich job RUNS (not skipped)
# 3. New release gets created
# 4. .version bumps
```

## Success Criteria

- [x] Workflow file line 71 adds output variable
- [ ] Manual dispatch test creates release
- [ ] Sync-and-enrich job runs (not skipped)
- [ ] Release appears in GitHub Releases

## Related Issues

Addresses repository cleanup issue #1 (workflow bug blocking releases).