### PR TITLE
fix: use separate commands for PR creation and auto-merge

### DIFF
--- a/.github/workflows/sync-and-enrich.yml
+++ b/.github/workflows/sync-and-enrich.yml
@@ -467,14 +467,17 @@ jobs:
 
             PR_BODY="Automated version bump for ${BUMP_TYPE} release."
 
-            gh pr create \
+            # Create PR
+            PR_URL=$(gh pr create \
               --title "chore: bump version to v${VERSION}" \
               --body "${PR_BODY}" \
               --base main \
-              --head "$BRANCH_NAME" \
-              --auto || echo "Note: Enable auto-merge in repo settings for fully automated workflow"
+              --head "$BRANCH_NAME")
 
-            echo "Version bump PR created: https://github.com/${{ github.repository }}/pulls"
+            echo "Version bump PR created: $PR_URL"
+
+            # Enable auto-merge on the created PR
+            gh pr merge "$PR_URL" --auto --squash || echo "Note: Auto-merge failed - may need to enable in repo settings"
           else
             echo "No changes to commit"
           fi


### PR DESCRIPTION
## Problem

PR #435 attempted to fix version bump PR creation by changing `--autoMerge` to `--auto`, but **`--auto` is not a valid flag for `gh pr create`**.

Workflow run 21050649224 showed the error:
```
Usage:  gh pr create [flags]
Note: Enable auto-merge in repo settings for fully automated workflow
```

The PR was never created because the command failed.

## Root Cause

The `--auto` flag is for `gh pr merge`, **not** for `gh pr create`. To enable auto-merge:
1. First create the PR with `gh pr create`
2. Then enable auto-merge with `gh pr merge --auto`

## Solution

Split into two separate commands:
```bash
# Create PR and capture URL
PR_URL=$(gh pr create \
  --title "chore: bump version to v${VERSION}" \
  --body "${PR_BODY}" \
  --base main \
  --head "$BRANCH_NAME")

# Enable auto-merge on the created PR
gh pr merge "$PR_URL" --auto --squash
```

## Impact

Future automated version bump PRs will:
- ✅ Be created successfully (no invalid flag error)
- ✅ Have auto-merge enabled automatically
- ✅ Merge when checks pass with no manual intervention

## Verification

This completes the 100% automated CI/CD pipeline:
- ✅ Workflow detects updates (PR #425)
- ✅ Releases created automatically (tested: v2.0.22, v2.0.23)
- ✅ Version bump PRs will be created AND auto-merged (this fix)

Related:
- PR #435: Incorrect fix attempt
- Workflow run 21050649224: Where the issue was discovered
- Manual fix: PR #436 (version bump to 2.0.23)