### PR TITLE
fix: add pull-requests write permission for version bump PR creation

### DIFF
--- a/.github/workflows/sync-and-enrich.yml
+++ b/.github/workflows/sync-and-enrich.yml
@@ -21,6 +21,7 @@ permissions:
   id-token: write
   issues: write
   actions: read
+  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Problem

Workflow run 21050957501 failed at the "Create version bump PR" step with error:
```
pull request create failed: GraphQL: Resource not accessible by integration (createPullRequest)
##[error]Process completed with exit code 1.
```

## Root Cause

The `GITHUB_TOKEN` used by the workflow did not have permission to create pull requests. The workflow's `permissions` block was missing `pull-requests: write`.

Current permissions:
```yaml
permissions:
  contents: write
  pages: write
  id-token: write
  issues: write
  actions: read
  # Missing: pull-requests: write
```

## Solution

Add `pull-requests: write` to the workflow permissions block:
```yaml
permissions:
  contents: write
  pages: write
  id-token: write
  issues: write
  actions: read
  pull-requests: write  # ← Added
```

## Impact

This enables the workflow to:
- ✅ Create version bump PRs automatically
- ✅ Enable auto-merge on created PRs
- ✅ Complete fully automated CI/CD pipeline with zero manual intervention

## Verification

After this PR merges:
- Future workflow runs will successfully create version bump PRs
- Auto-merge will be enabled automatically
- Complete automation achieved (no manual PR creation needed)

## Related

- Workflow run 21050957501: Where the permission error occurred
- Branch version-bump/v2.0.24: Created but PR creation failed
- PR #439: Manual version bump to 2.0.24 (temporary workaround)
- PR #437: Fixed PR creation + auto-merge commands (but needs this permission)