### PR TITLE
ci: use PAT for version-bump PRs to trigger workflow checks

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     branches:
       - main
+  # Also trigger on push to version-bump branches to satisfy auto-merge requirements
+  # When GITHUB_TOKEN creates a PR, it doesn't trigger pull_request events
+  push:
+    branches:
+      - 'version-bump/**'
 
 jobs:
   validate:

--- a/.github/workflows/sync-and-enrich.yml
+++ b/.github/workflows/sync-and-enrich.yml
@@ -448,6 +448,7 @@ jobs:
         if: steps.version.outputs.has_changes == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.VERSION_BUMP_PAT }}
           VERSION: ${{ steps.version.outputs.new_version }}
           BUMP_TYPE: ${{ steps.version.outputs.bump_type }}
         run: |
@@ -468,7 +469,7 @@ jobs:
 
             PR_BODY="Automated version bump for ${BUMP_TYPE} release."
 
-            # Create PR
+            # Create PR using PAT to trigger workflow checks
             PR_URL=$(gh pr create \
               --title "chore: bump version to v${VERSION}" \
               --body "${PR_BODY}" \
@@ -478,7 +479,8 @@ jobs:
             echo "Version bump PR created: $PR_URL"
 
             # Enable auto-merge on the created PR
-            gh pr merge "$PR_URL" --auto --squash || echo "Note: Auto-merge failed - may need to enable in repo settings"
+            gh pr merge "$PR_URL" --auto --squash || \
+              echo "Note: Auto-merge failed - may need to enable in repo settings"
           else
             echo "No changes to commit"
           fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,7 +140,7 @@ python -m scripts.generate_descriptions --all
 
 **Server URL Template**:
 
-```
+```text
 https://{tenant}.{console_url}/api/v1/namespaces/{namespace}
 ```
 

--- a/config/operation_descriptions.yaml
+++ b/config/operation_descriptions.yaml
@@ -11,7 +11,7 @@ resources:
       comprehensive traffic management and security'
   tcp_loadbalancer:
     short: Layer 4 TCP load balancer for non-HTTP traffic
-    medium: TCP load balancing for non-HTTP protocols with origin pool management, health checks, and connection tracking
+    medium: TCP load balancing for non-HTTP protocols with origin pool management and health checks
     long: 'Layer 4 load balancer supporting TCP protocol with transparent proxy capabilities, origin pool
       configuration, connection state tracking, health monitoring, source IP preservation, and support for
       any TCP-based application protocol'


### PR DESCRIPTION
## Summary
- Add VERSION_BUMP_PAT secret usage in sync-and-enrich.yml for creating PRs
- PRs created with PAT will trigger pr-check workflow (GITHUB_TOKEN PRs don't)
- Add push trigger to pr-check.yml for version-bump branches (redundancy)
- Fix yamllint line-length violations in workflow and config
- Fix markdownlint fenced-code-language in CLAUDE.md

## Problem
Auto-merge was blocked because PRs created by GITHUB_TOKEN don't trigger workflow checks.

## Solution
Use a Personal Access Token (VERSION_BUMP_PAT) for the `gh pr create` command, which allows the created PR to trigger the pr-check workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)