### PR TITLE
feat: add validation specification export and centralized schema

### DIFF
--- a/config/validation_schema.yaml
+++ b/config/validation_schema.yaml
@@ -1,0 +1,514 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+#
+# Centralized Validation Schema for F5 XC API
+#
+# This file serves as the single source of truth for API validation constraints
+# to be consumed by downstream projects (CLI tools, Terraform providers, AI assistants).
+#
+# Version: 1.0.0
+# See: docs/VALIDATION_SPEC.md for consumer documentation
+
+version: "1.0.0"
+description: "Centralized validation specification for F5 XC API"
+
+# =============================================================================
+# EXPORT CONFIGURATION
+# =============================================================================
+
+export:
+  # Output path for generated validation.json
+  output_path: "docs/specifications/api/validation.json"
+
+  # Include these sections in exported validation spec
+  include_sections:
+    - required_fields
+    - enum_values
+    - constraints
+    - patterns
+    - server_defaults
+    - conditional_requirements
+    - minimum_configurations
+
+  # JSON Schema version for exported schema
+  json_schema_version: "https://json-schema.org/draft/2020-12/schema"
+
+# =============================================================================
+# REQUIRED FIELDS BY OPERATION
+# =============================================================================
+
+required_fields:
+  # Common metadata fields required for all resources
+  common:
+    all_operations:
+      - "metadata.name"
+      - "metadata.namespace"
+
+  # Per-resource required fields
+  resources:
+    http_loadbalancer:
+      create:
+        - "metadata.name"
+        - "metadata.namespace"
+        - "spec.domains"
+        - "spec.routes"
+        - "spec.origin_pools"
+      update:
+        - "metadata.name"
+        - "metadata.namespace"
+      minimum_config:
+        - "metadata.name"
+        - "metadata.namespace"
+        - "spec.domains"
+
+    origin_pool:
+      create:
+        - "metadata.name"
+        - "metadata.namespace"
+        - "spec.origin_servers"
+        - "spec.port"
+      update:
+        - "metadata.name"
+        - "metadata.namespace"
+      minimum_config:
+        - "metadata.name"
+        - "metadata.namespace"
+        - "spec.origin_servers"
+        - "spec.port"
+
+    healthcheck:
+      create:
+        - "metadata.name"
+        - "metadata.namespace"
+        - "spec.interval"
+        - "spec.timeout"
+        - "spec.healthy_threshold"
+        - "spec.unhealthy_threshold"
+      update:
+        - "metadata.name"
+        - "metadata.namespace"
+      minimum_config:
+        - "metadata.name"
+        - "metadata.namespace"
+        - "spec.interval"
+        - "spec.timeout"
+        - "spec.healthy_threshold"
+        - "spec.unhealthy_threshold"
+
+    tcp_loadbalancer:
+      create:
+        - "metadata.name"
+        - "metadata.namespace"
+        - "spec.origin_pools"
+      update:
+        - "metadata.name"
+        - "metadata.namespace"
+      minimum_config:
+        - "metadata.name"
+        - "metadata.namespace"
+        - "spec.origin_pools"
+
+    app_firewall:
+      create:
+        - "metadata.name"
+        - "metadata.namespace"
+      update:
+        - "metadata.name"
+        - "metadata.namespace"
+      minimum_config:
+        - "metadata.name"
+        - "metadata.namespace"
+
+    certificate:
+      create:
+        - "metadata.name"
+        - "metadata.namespace"
+        - "spec.certificate_url"
+      update:
+        - "metadata.name"
+        - "metadata.namespace"
+      minimum_config:
+        - "metadata.name"
+        - "metadata.namespace"
+        - "spec.certificate_url"
+
+    service_policy:
+      create:
+        - "metadata.name"
+        - "metadata.namespace"
+      update:
+        - "metadata.name"
+        - "metadata.namespace"
+      minimum_config:
+        - "metadata.name"
+        - "metadata.namespace"
+
+# =============================================================================
+# ENUM/ALLOWED VALUES
+# =============================================================================
+
+enum_values:
+  # Load balancing algorithms
+  loadbalancer_algorithm:
+    description: "Load balancing algorithm for distributing traffic across origin servers"
+    values:
+      - value: "ROUND_ROBIN"
+        description: "Each healthy endpoint selected in round robin order"
+        is_default: true
+      - value: "LEAST_REQUEST"
+        description: "Endpoint with fewest active requests selected"
+      - value: "RING_HASH"
+        description: "Consistent hashing using ring hash of endpoint names"
+      - value: "RANDOM"
+        description: "Random healthy endpoint selection"
+      - value: "LB_OVERRIDE"
+        description: "Hash policy inherited from parent load balancer"
+
+  # Endpoint selection policy
+  endpoint_selection:
+    description: "Policy for selecting endpoints from local and remote sites"
+    values:
+      - value: "DISTRIBUTED"
+        description: "Consider both remote and local endpoints for load balancing"
+        is_default: true
+      - value: "LOCAL_ONLY"
+        description: "Only local endpoints used for load balancing"
+      - value: "LOCAL_PREFERRED"
+        description: "Prefer local endpoints, fall back to remote if unavailable"
+
+  # Health check types
+  health_check_type:
+    description: "Type of health check to perform"
+    values:
+      - value: "HTTP"
+        description: "HTTP/HTTPS health check with configurable path and headers"
+      - value: "TCP"
+        description: "TCP connection health check"
+      - value: "UDP"
+        description: "UDP/ICMP health check"
+
+  # WAF detection modes
+  waf_mode:
+    description: "WAF operation mode"
+    values:
+      - value: "MONITORING"
+        description: "Log threats without blocking (default)"
+        is_default: true
+      - value: "BLOCKING"
+        description: "Block detected threats"
+
+  # TLS configuration
+  tls_mode:
+    description: "TLS termination mode"
+    values:
+      - value: "NO_TLS"
+        description: "No TLS, plaintext connection"
+        is_default: true
+      - value: "TLS"
+        description: "TLS enabled with certificate"
+      - value: "MTLS"
+        description: "Mutual TLS with client certificate verification"
+
+# =============================================================================
+# VALIDATION CONSTRAINTS BY FIELD TYPE/PATTERN
+# =============================================================================
+
+constraints:
+  # Type-level defaults (applied to all fields of this type)
+  type_defaults:
+    string:
+      minLength: 0
+      maxLength: 1024
+      comment: "Conservative default for string fields"
+
+    integer:
+      minimum: 0
+      maximum: 2147483647  # int32 max
+      comment: "Conservative default for integer fields"
+
+  # Pattern-based constraints (matched against field names)
+  patterns:
+    - pattern: '\bport$'
+      constraints:
+        minimum: 1
+        maximum: 65535
+      confidence: 0.99
+      comment: "Valid TCP/UDP port range"
+
+    - pattern: '\b(vlan)?_?id$'
+      constraints:
+        minimum: 1
+        maximum: 4094
+      confidence: 0.95
+      comment: "Valid VLAN ID range (802.1Q)"
+
+    - pattern: '\bemail$'
+      constraints:
+        format: 'email'
+        pattern: '^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$'
+      confidence: 0.99
+      comment: "RFC 5322 compliant email validation"
+
+    - pattern: '\burl$'
+      constraints:
+        format: 'uri'
+      confidence: 0.95
+      comment: "URL must be valid URI format"
+
+    - pattern: '\buuid$'
+      constraints:
+        format: 'uuid'
+      confidence: 0.99
+      comment: "UUID format validation (RFC 4122)"
+
+    - pattern: '\btimestamp$'
+      constraints:
+        format: 'date-time'
+      confidence: 0.95
+      comment: "ISO 8601 date-time format"
+
+    - pattern: '\b(ipv4|ipaddress|ip_addr)$'
+      constraints:
+        format: 'ipv4'
+      confidence: 0.95
+      comment: "IPv4 address format validation"
+
+    - pattern: '\bname$'
+      constraints:
+        minLength: 1
+        maxLength: 63
+        pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
+      confidence: 0.90
+      comment: "Kubernetes-style naming convention"
+
+    - pattern: '\bnamespace$'
+      constraints:
+        minLength: 1
+        maxLength: 63
+        pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
+      confidence: 0.95
+      comment: "Kubernetes namespace naming convention"
+
+    - pattern: '\b(interval|timeout)$'
+      constraints:
+        minimum: 1
+        maximum: 600
+      confidence: 0.90
+      comment: "Time duration in seconds (1s to 10min)"
+
+    - pattern: '\b(healthy_threshold|unhealthy_threshold)$'
+      constraints:
+        minimum: 1
+        maximum: 16
+      confidence: 0.95
+      comment: "Health check threshold count"
+
+    - pattern: '\bjitter_percent$'
+      constraints:
+        minimum: 0
+        maximum: 100
+      confidence: 0.95
+      comment: "Percentage value for jitter"
+
+# =============================================================================
+# SERVER-APPLIED DEFAULTS
+# =============================================================================
+
+server_defaults:
+  description: "Values automatically applied by the F5 XC API when fields are omitted"
+
+  resources:
+    origin_pool:
+      spec:
+        no_tls: {}
+        healthcheck: []
+        loadbalancer_algorithm: "ROUND_ROBIN"
+        endpoint_selection: "DISTRIBUTED"
+
+    healthcheck:
+      spec:
+        jitter: 0
+        jitter_percent: 0
+
+    app_firewall:
+      spec:
+        allow_all_response_codes: {}
+        default_anonymization: {}
+        default_bot_setting: {}
+        default_detection_settings: {}
+        disable_ai_enhancements: {}
+        monitoring: {}
+        use_default_blocking_page: {}
+
+# =============================================================================
+# CONDITIONAL REQUIREMENTS
+# =============================================================================
+
+conditional_requirements:
+  description: "Fields required or mutually exclusive based on context"
+
+  resources:
+    http_loadbalancer:
+      mutually_exclusive:
+        - fields: ["spec.dns_name", "spec.advertise"]
+          reason: "Choose either DNS-based or advertised traffic routing"
+        - fields: ["spec.certificate_chain", "spec.tls_config.vault_secret"]
+          reason: "Certificate source: inline or vault"
+      conditional:
+        - field: "spec.certificate"
+          required_when:
+            field: "spec.https"
+            condition: "present"
+          reason: "Required for TLS termination"
+
+    healthcheck:
+      mutually_exclusive:
+        - fields: ["spec.http_health_check", "spec.tcp_health_check", "spec.udp_icmp_health_check"]
+          reason: "Choose exactly one health check type"
+
+    tcp_loadbalancer:
+      mutually_exclusive:
+        - fields: ["spec.listen_port", "spec.port_ranges"]
+          reason: "Specify either a single port or port ranges (port_choice)"
+        - fields: ["spec.listener.tcp_port", "spec.listener.udp_port"]
+          reason: "Specify either TCP or UDP protocol"
+
+    service_policy:
+      mutually_exclusive:
+        - fields:
+            - "spec.allow_all_requests"
+            - "spec.deny_all_requests"
+            - "spec.allow_list"
+            - "spec.deny_list"
+            - "spec.rule_list"
+          reason: "Choose exactly one rule type"
+
+# =============================================================================
+# MINIMUM CONFIGURATIONS
+# =============================================================================
+
+minimum_configurations:
+  description: "Minimum viable configuration for creating resources"
+
+  resources:
+    http_loadbalancer:
+      description: "HTTP/HTTPS load balancer for distributing traffic across origin pools"
+      example_json: |
+        {
+          "metadata": {
+            "name": "example-lb",
+            "namespace": "default"
+          },
+          "spec": {
+            "domains": ["example.com"],
+            "http": [{"port": 80}],
+            "routes": [{"prefix": "/", "origin_pool": {"pool_name": "pool"}}],
+            "origin_pools": [{"name": "pool", "origins": [{"hostname": "backend.example.com"}]}]
+          }
+        }
+
+    origin_pool:
+      description: "Backend origin servers for load balancing"
+      example_json: |
+        {
+          "metadata": {
+            "name": "backend-pool",
+            "namespace": "default"
+          },
+          "spec": {
+            "origin_servers": [
+              {"public_name": {"dns_name": "backend1.example.com"}},
+              {"public_name": {"dns_name": "backend2.example.com"}}
+            ],
+            "port": 8080
+          }
+        }
+
+    healthcheck:
+      description: "Health check configuration for monitoring origin servers"
+      example_json: |
+        {
+          "metadata": {
+            "name": "http-health",
+            "namespace": "default"
+          },
+          "spec": {
+            "http_health_check": {"path": "/health", "use_origin_server_hostname": true},
+            "interval": 15,
+            "timeout": 3,
+            "unhealthy_threshold": 1,
+            "healthy_threshold": 3,
+            "jitter_percent": 30
+          }
+        }
+
+    tcp_loadbalancer:
+      description: "TCP/UDP load balancer for non-HTTP protocols"
+      example_json: |
+        {
+          "metadata": {
+            "name": "database-lb",
+            "namespace": "default"
+          },
+          "spec": {
+            "listener": {"port": 5432, "protocol": "TCP"},
+            "origin_pools": [{"pool_name": "postgres-cluster"}]
+          }
+        }
+
+    app_firewall:
+      description: "Web Application Firewall (WAF) policy"
+      example_json: |
+        {
+          "metadata": {
+            "name": "default-waf",
+            "namespace": "default"
+          },
+          "spec": {
+            "detection_settings": {"signature_detection": true},
+            "monitoring": {}
+          }
+        }
+
+    certificate:
+      description: "TLS certificate for securing HTTPS endpoints"
+      example_json: |
+        {
+          "metadata": {
+            "name": "example-cert",
+            "namespace": "default"
+          },
+          "spec": {
+            "certificate_url": "string:///BASE64_ENCODED_CERTIFICATE"
+          }
+        }
+
+# =============================================================================
+# EXTENSION MAPPING
+# =============================================================================
+
+extension_mapping:
+  description: "OpenAPI extension field names used in enriched specs"
+
+  required_for: "x-f5xc-required-for"
+  server_default: "x-f5xc-server-default"
+  recommended_value: "x-f5xc-recommended-value"
+  conditions: "x-f5xc-conditions"
+  minimum_configuration: "x-f5xc-minimum-configuration"
+  validation: "x-f5xc-validation"
+
+# =============================================================================
+# RECONCILIATION STRATEGY
+# =============================================================================
+
+reconciliation:
+  description: "Strategy for resolving conflicts between constraint sources"
+
+  priority_order:
+    - "existing"    # Constraints in original OpenAPI spec (highest priority)
+    - "discovery"   # Constraints from live API discovery
+    - "inferred"    # Constraints from pattern matching (lowest priority)
+
+  behavior:
+    existing_wins: true
+    log_conflicts: true
+    merge_non_conflicting: true

--- a/docs/VALIDATION_SPEC.md
+++ b/docs/VALIDATION_SPEC.md
@@ -1,0 +1,463 @@
+# F5 XC API Validation Specification
+
+Centralized validation specification for downstream projects consuming the F5 XC API.
+
+## Overview
+
+The f5xc-api-enriched project serves as the **single source of truth** for API validation constraints. Downstream projects (CLI tools, Terraform providers, AI assistants) should consume this centralized validation metadata rather than maintaining their own validation logic.
+
+### Why Centralized?
+
+| Factor | Centralized | Per-Project |
+|--------|-------------|-------------|
+| Consistency | All consumers validate the same way | Drift between implementations |
+| Maintenance | Update once, propagate everywhere | N implementations to update |
+| Discovery | Already have infrastructure | Each project rediscovers constraints |
+| Accuracy | Derived from actual API behavior | May diverge from real API |
+| Cost | One validation test suite | N test suites |
+
+## Validation Specification Format
+
+The validation specification is published as `docs/specifications/api/validation.json` and contains:
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "version": "1.0.0",
+  "generated_at": "2026-01-17T12:00:00Z",
+  "source": "f5xc-api-enriched",
+
+  "required_fields": { ... },
+  "enum_values": { ... },
+  "constraints": { ... },
+  "patterns": [ ... ],
+  "server_defaults": { ... },
+  "conditional_requirements": { ... },
+  "minimum_configurations": { ... },
+  "extensions": { ... }
+}
+```
+
+## Sections
+
+### Required Fields
+
+Specifies which fields are required for each operation (create, update, minimum_config).
+
+```json
+{
+  "required_fields": {
+    "common": {
+      "all_operations": ["metadata.name", "metadata.namespace"]
+    },
+    "resources": {
+      "origin_pool": {
+        "create": ["metadata.name", "metadata.namespace", "spec.origin_servers", "spec.port"],
+        "update": ["metadata.name", "metadata.namespace"],
+        "minimum_config": ["metadata.name", "metadata.namespace", "spec.origin_servers", "spec.port"]
+      }
+    }
+  }
+}
+```
+
+**Usage in downstream projects:**
+
+```python
+# Python example
+def validate_create(resource_type: str, data: dict) -> list[str]:
+    spec = load_validation_spec()
+    required = spec["required_fields"]["resources"].get(resource_type, {}).get("create", [])
+    errors = []
+    for field in required:
+        if not get_nested(data, field):
+            errors.append(f"Required field missing: {field}")
+    return errors
+```
+
+```go
+// Go example
+func ValidateCreate(resourceType string, data map[string]interface{}) []string {
+    spec := LoadValidationSpec()
+    required := spec.RequiredFields.Resources[resourceType].Create
+    var errors []string
+    for _, field := range required {
+        if !HasNestedField(data, field) {
+            errors = append(errors, fmt.Sprintf("Required field missing: %s", field))
+        }
+    }
+    return errors
+}
+```
+
+### Enum Values
+
+Defines allowed values for constrained fields.
+
+```json
+{
+  "enum_values": {
+    "loadbalancer_algorithm": {
+      "description": "Load balancing algorithm for distributing traffic across origin servers",
+      "values": [
+        {"value": "ROUND_ROBIN", "description": "Each healthy endpoint selected in round robin order"},
+        {"value": "LEAST_REQUEST", "description": "Endpoint with fewest active requests selected"},
+        {"value": "RING_HASH", "description": "Consistent hashing using ring hash of endpoint names"},
+        {"value": "RANDOM", "description": "Random healthy endpoint selection"},
+        {"value": "LB_OVERRIDE", "description": "Hash policy inherited from parent load balancer"}
+      ],
+      "default": "ROUND_ROBIN"
+    }
+  }
+}
+```
+
+**Usage:**
+
+```python
+def validate_enum(field_name: str, value: str, enum_type: str) -> bool:
+    spec = load_validation_spec()
+    enum_def = spec["enum_values"].get(enum_type)
+    if not enum_def:
+        return True  # No constraint
+    allowed = [v["value"] for v in enum_def["values"]]
+    return value in allowed
+```
+
+### Constraints
+
+Type-level validation defaults and pattern-based rules.
+
+```json
+{
+  "constraints": {
+    "type_defaults": {
+      "string": {"minLength": 0, "maxLength": 1024},
+      "integer": {"minimum": 0, "maximum": 2147483647}
+    }
+  }
+}
+```
+
+### Patterns
+
+Field name pattern-based validation rules with confidence scores.
+
+```json
+{
+  "patterns": [
+    {
+      "pattern": "\\bport$",
+      "constraints": {"minimum": 1, "maximum": 65535},
+      "confidence": 0.99,
+      "description": "Valid TCP/UDP port range"
+    },
+    {
+      "pattern": "\\bname$",
+      "constraints": {
+        "minLength": 1,
+        "maxLength": 63,
+        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+      },
+      "confidence": 0.90,
+      "description": "Kubernetes-style naming convention"
+    }
+  ]
+}
+```
+
+**Usage:**
+
+```python
+import re
+
+def get_field_constraints(field_name: str) -> dict:
+    spec = load_validation_spec()
+    constraints = {}
+    for pattern_def in spec["patterns"]:
+        if re.search(pattern_def["pattern"], field_name):
+            constraints.update(pattern_def["constraints"])
+    return constraints
+```
+
+### Server Defaults
+
+Values automatically applied by the F5 XC API when fields are omitted.
+
+```json
+{
+  "server_defaults": {
+    "description": "Values automatically applied by the F5 XC API when fields are omitted",
+    "resources": {
+      "origin_pool": {
+        "spec": {
+          "no_tls": {},
+          "healthcheck": [],
+          "loadbalancer_algorithm": "ROUND_ROBIN",
+          "endpoint_selection": "DISTRIBUTED"
+        }
+      }
+    }
+  }
+}
+```
+
+**Usage in CLI help text:**
+
+```
+$ xcsh origin-pool create --help
+
+DEFAULTS (server-applied):
+  --loadbalancer-algorithm  ROUND_ROBIN (if omitted)
+  --endpoint-selection      DISTRIBUTED (if omitted)
+```
+
+### Conditional Requirements
+
+Mutually exclusive fields and conditional dependencies.
+
+```json
+{
+  "conditional_requirements": {
+    "resources": {
+      "healthcheck": {
+        "mutually_exclusive": [
+          {
+            "fields": ["spec.http_health_check", "spec.tcp_health_check", "spec.udp_icmp_health_check"],
+            "reason": "Choose exactly one health check type"
+          }
+        ],
+        "conditional": []
+      }
+    }
+  }
+}
+```
+
+**Usage:**
+
+```python
+def validate_mutually_exclusive(resource_type: str, data: dict) -> list[str]:
+    spec = load_validation_spec()
+    requirements = spec["conditional_requirements"]["resources"].get(resource_type, {})
+    errors = []
+
+    for exclusion in requirements.get("mutually_exclusive", []):
+        present = [f for f in exclusion["fields"] if get_nested(data, f)]
+        if len(present) > 1:
+            errors.append(f"Mutually exclusive fields: {', '.join(present)}. {exclusion['reason']}")
+
+    return errors
+```
+
+### Minimum Configurations
+
+Minimum viable configurations with working examples.
+
+```json
+{
+  "minimum_configurations": {
+    "resources": {
+      "origin_pool": {
+        "description": "Backend origin servers for load balancing",
+        "example": {
+          "metadata": {"name": "backend-pool", "namespace": "default"},
+          "spec": {
+            "origin_servers": [{"public_name": {"dns_name": "backend1.example.com"}}],
+            "port": 8080
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## OpenAPI Extension Mapping
+
+The enriched OpenAPI specs use these extensions to embed validation metadata:
+
+| Extension | Purpose | Location |
+|-----------|---------|----------|
+| `x-f5xc-required-for` | Context-specific required fields | Schema properties |
+| `x-f5xc-server-default` | Marks server-applied defaults | Schema properties |
+| `x-f5xc-recommended-value` | Recommended default value | Schema properties |
+| `x-f5xc-conditions` | Conditional requirements | Schema properties |
+| `x-f5xc-minimum-configuration` | Minimum config examples | Schema definitions |
+| `x-f5xc-validation` | Discovery-derived constraints | Schema properties |
+
+## Integration Examples
+
+### CLI Tool (Python)
+
+```python
+import json
+from pathlib import Path
+
+class F5XCValidator:
+    def __init__(self, spec_path: str = "validation.json"):
+        with open(spec_path) as f:
+            self.spec = json.load(f)
+
+    def validate_resource(self, resource_type: str, operation: str, data: dict) -> list[str]:
+        errors = []
+
+        # Check required fields
+        required = self.spec["required_fields"]["resources"].get(resource_type, {}).get(operation, [])
+        for field in required:
+            if not self._get_nested(data, field):
+                errors.append(f"Missing required field: {field}")
+
+        # Check enum values
+        errors.extend(self._validate_enums(resource_type, data))
+
+        # Check mutually exclusive fields
+        errors.extend(self._validate_mutual_exclusions(resource_type, data))
+
+        return errors
+
+    def get_server_defaults(self, resource_type: str) -> dict:
+        return self.spec["server_defaults"]["resources"].get(resource_type, {})
+
+    def get_minimum_config(self, resource_type: str) -> dict:
+        return self.spec["minimum_configurations"]["resources"].get(resource_type, {}).get("example", {})
+```
+
+### Terraform Provider (Go)
+
+```go
+package validation
+
+import (
+    "encoding/json"
+    "regexp"
+)
+
+type ValidationSpec struct {
+    RequiredFields           RequiredFieldsSpec           `json:"required_fields"`
+    EnumValues               map[string]EnumSpec          `json:"enum_values"`
+    Patterns                 []PatternSpec                `json:"patterns"`
+    ServerDefaults           ServerDefaultsSpec           `json:"server_defaults"`
+    ConditionalRequirements  ConditionalRequirementsSpec  `json:"conditional_requirements"`
+    MinimumConfigurations    MinimumConfigSpec            `json:"minimum_configurations"`
+}
+
+func (v *ValidationSpec) ValidateCreate(resourceType string, data map[string]interface{}) []error {
+    var errors []error
+
+    if fields, ok := v.RequiredFields.Resources[resourceType]; ok {
+        for _, field := range fields.Create {
+            if !hasNestedField(data, field) {
+                errors = append(errors, fmt.Errorf("required field missing: %s", field))
+            }
+        }
+    }
+
+    return errors
+}
+
+func (v *ValidationSpec) GetFieldConstraints(fieldName string) map[string]interface{} {
+    constraints := make(map[string]interface{})
+
+    for _, pattern := range v.Patterns {
+        if matched, _ := regexp.MatchString(pattern.Pattern, fieldName); matched {
+            for k, v := range pattern.Constraints {
+                constraints[k] = v
+            }
+        }
+    }
+
+    return constraints
+}
+```
+
+### AI Assistant (MCP Server)
+
+```python
+class F5XCValidationTool:
+    """MCP tool for AI assistants to validate F5 XC configurations."""
+
+    def __init__(self):
+        self.spec = self._load_validation_spec()
+
+    def get_required_fields(self, resource_type: str, operation: str = "create") -> list[str]:
+        """Get required fields for a resource operation."""
+        return self.spec["required_fields"]["resources"].get(resource_type, {}).get(operation, [])
+
+    def get_allowed_values(self, enum_type: str) -> list[str]:
+        """Get allowed values for an enum field."""
+        enum_def = self.spec["enum_values"].get(enum_type, {})
+        return [v["value"] for v in enum_def.get("values", [])]
+
+    def get_minimum_example(self, resource_type: str) -> dict:
+        """Get minimum working configuration example."""
+        return self.spec["minimum_configurations"]["resources"].get(resource_type, {}).get("example", {})
+
+    def suggest_fix(self, resource_type: str, error_message: str) -> str:
+        """Suggest a fix based on validation error."""
+        # AI can use this to provide helpful suggestions
+        pass
+```
+
+## Fetching the Validation Spec
+
+The validation specification is published alongside the OpenAPI specs:
+
+```bash
+# Via GitHub Pages
+curl -O https://robinmordasiewicz.github.io/f5xc-api-enriched/specifications/api/validation.json
+
+# Via raw GitHub
+curl -O https://raw.githubusercontent.com/robinmordasiewicz/f5xc-api-enriched/main/docs/specifications/api/validation.json
+```
+
+## Versioning
+
+The validation spec follows semantic versioning:
+
+- **Major**: Breaking changes to structure or field names
+- **Minor**: New validation rules or resources added
+- **Patch**: Bug fixes or description updates
+
+Check the `version` field in the spec to ensure compatibility:
+
+```python
+spec = load_validation_spec()
+if not spec["version"].startswith("1."):
+    raise ValueError(f"Unsupported validation spec version: {spec['version']}")
+```
+
+## Reconciliation Strategy
+
+When multiple sources provide constraints, the reconciliation priority is:
+
+1. **Existing** - Constraints in original OpenAPI spec (highest priority)
+2. **Discovery** - Constraints from live API discovery
+3. **Inferred** - Constraints from pattern matching (lowest priority)
+
+This ensures manually curated constraints take precedence while still benefiting from automated discovery.
+
+## What Downstream Projects Should Own
+
+While validation rules are centralized, downstream projects still own:
+
+| Project | Project-Specific Concerns |
+|---------|---------------------------|
+| **CLI Tools** | Flag parsing, shell completion, interactive prompts, help text formatting |
+| **Terraform** | State management, plan/apply logic, provider-specific schema types |
+| **AI Assistants** | Context window management, prompt optimization, response formatting |
+| **All** | Network timeouts, retry logic, authentication, error display |
+
+## Contributing
+
+To add or update validation rules:
+
+1. Edit `config/validation_schema.yaml`
+2. Run the pipeline to regenerate `validation.json`
+3. Submit a PR with justification for the change
+
+## Related Documentation
+
+- [CLAUDE.md](../CLAUDE.md) - AI assistant instructions
+- [DEVELOPMENT.md](DEVELOPMENT.md) - Developer guide
+- [config/validation_schema.yaml](../config/validation_schema.yaml) - Source configuration

--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -92,6 +92,7 @@ from scripts.utils import (
     SchemaFixer,
     TagGenerator,
     ValidationEnricher,
+    ValidationExporter,
     categorize_spec,
 )
 from scripts.utils.batch_processor import BatchSpecProcessor
@@ -1634,6 +1635,20 @@ def run_pipeline(
             # Create index
             index = create_spec_index(domain_specs, version)
             save_spec(index, output_dir / "index.json", indent=indent)
+
+            # Export validation specification for downstream consumers
+            try:
+                validation_exporter = ValidationExporter()
+                validation_exporter.export(output_dir / "validation.json")
+                validation_stats = validation_exporter.get_stats()
+                console.print(
+                    f"[green]Exported validation.json: "
+                    f"{validation_stats['resources_processed']} resources, "
+                    f"{validation_stats['required_fields_exported']} required fields, "
+                    f"{validation_stats['enum_values_exported']} enum values[/green]",
+                )
+            except Exception as e:
+                console.print(f"[yellow]Warning: Failed to export validation spec: {e}[/yellow]")
 
             console.print(f"[green]Created {len(domain_specs)} domain specs + master spec[/green]")
 

--- a/scripts/utils/__init__.py
+++ b/scripts/utils/__init__.py
@@ -33,6 +33,7 @@ from .resource_examples_enricher import ResourceExamplesEnricher
 from .schema_fixer import SchemaFixer
 from .tag_generator import TagGenerator
 from .validation_enricher import ValidationEnricher
+from .validation_exporter import ValidationExporter
 
 __all__ = [
     "AcronymEnricher",
@@ -69,5 +70,6 @@ __all__ = [
     "SchemaFixer",
     "TagGenerator",
     "ValidationEnricher",
+    "ValidationExporter",
     "categorize_spec",
 ]

--- a/scripts/utils/validation_exporter.py
+++ b/scripts/utils/validation_exporter.py
@@ -1,0 +1,376 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+"""Validation Specification Exporter.
+
+Exports centralized validation rules to a standalone JSON format
+for consumption by downstream projects (CLI tools, Terraform providers, AI assistants).
+
+Usage:
+    python -m scripts.utils.validation_exporter
+    python -m scripts.utils.validation_exporter --output path/to/output.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+@dataclass
+class ExporterStats:
+    """Statistics from validation export."""
+
+    resources_processed: int = 0
+    required_fields_exported: int = 0
+    enum_values_exported: int = 0
+    constraints_exported: int = 0
+    server_defaults_exported: int = 0
+    conditional_requirements_exported: int = 0
+    minimum_configs_exported: int = 0
+    warnings: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert stats to dictionary."""
+        return {
+            "resources_processed": self.resources_processed,
+            "required_fields_exported": self.required_fields_exported,
+            "enum_values_exported": self.enum_values_exported,
+            "constraints_exported": self.constraints_exported,
+            "server_defaults_exported": self.server_defaults_exported,
+            "conditional_requirements_exported": self.conditional_requirements_exported,
+            "minimum_configs_exported": self.minimum_configs_exported,
+            "warnings": self.warnings,
+        }
+
+
+class ValidationExporter:
+    """Export validation schema to standalone JSON format.
+
+    Reads the centralized validation_schema.yaml and generates
+    a machine-readable validation.json for downstream consumers.
+    """
+
+    def __init__(self, config_path: Path | None = None) -> None:
+        """Initialize exporter with validation schema configuration.
+
+        Args:
+            config_path: Path to validation_schema.yaml config.
+                        Defaults to config/validation_schema.yaml.
+        """
+        if config_path is None:
+            config_path = Path(__file__).parent.parent.parent / "config" / "validation_schema.yaml"
+
+        self.config_path = config_path
+        self.config: dict[str, Any] = {}
+        self.stats = ExporterStats()
+
+        self._load_config()
+
+    def _load_config(self) -> None:
+        """Load validation schema from YAML config."""
+        if not self.config_path.exists():
+            raise FileNotFoundError(f"Validation schema not found: {self.config_path}")
+
+        with self.config_path.open() as f:
+            self.config = yaml.safe_load(f) or {}
+
+    def export(self, output_path: Path | None = None) -> dict[str, Any]:
+        """Export validation schema to JSON format.
+
+        Args:
+            output_path: Optional path to write output. If provided,
+                        writes JSON to file. Always returns the dict.
+
+        Returns:
+            Validation specification dictionary.
+        """
+        # Build the exported validation spec
+        validation_spec = self._build_validation_spec()
+
+        # Write to file if path provided
+        if output_path:
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            with output_path.open("w") as f:
+                json.dump(validation_spec, f, indent=2, ensure_ascii=False)
+                f.write("\n")
+
+        return validation_spec
+
+    def _build_validation_spec(self) -> dict[str, Any]:
+        """Build the complete validation specification."""
+        spec: dict[str, Any] = {
+            "$schema": self.config.get("export", {}).get(
+                "json_schema_version",
+                "https://json-schema.org/draft/2020-12/schema",
+            ),
+            "version": self.config.get("version", "1.0.0"),
+            "description": self.config.get("description", "F5 XC API Validation Specification"),
+            "generated_at": datetime.now(tz=timezone.utc).isoformat(),
+            "source": "f5xc-api-enriched",
+        }
+
+        # Build sections based on export configuration
+        include_sections = self.config.get("export", {}).get("include_sections", [])
+
+        if "required_fields" in include_sections or not include_sections:
+            spec["required_fields"] = self._export_required_fields()
+
+        if "enum_values" in include_sections or not include_sections:
+            spec["enum_values"] = self._export_enum_values()
+
+        if "constraints" in include_sections or not include_sections:
+            spec["constraints"] = self._export_constraints()
+
+        if "patterns" in include_sections or not include_sections:
+            spec["patterns"] = self._export_patterns()
+
+        if "server_defaults" in include_sections or not include_sections:
+            spec["server_defaults"] = self._export_server_defaults()
+
+        if "conditional_requirements" in include_sections or not include_sections:
+            spec["conditional_requirements"] = self._export_conditional_requirements()
+
+        if "minimum_configurations" in include_sections or not include_sections:
+            spec["minimum_configurations"] = self._export_minimum_configurations()
+
+        # Add extension mapping for downstream tools
+        spec["extensions"] = self._export_extension_mapping()
+
+        # Add reconciliation strategy info
+        spec["reconciliation"] = self.config.get("reconciliation", {})
+
+        # Add export statistics
+        spec["_stats"] = self.stats.to_dict()
+
+        return spec
+
+    def _export_required_fields(self) -> dict[str, Any]:
+        """Export required fields by resource and operation."""
+        required_fields_config = self.config.get("required_fields", {})
+        result: dict[str, Any] = {
+            "common": required_fields_config.get("common", {}),
+            "resources": {},
+        }
+
+        resources = required_fields_config.get("resources", {})
+        for resource_name, operations in resources.items():
+            result["resources"][resource_name] = {}
+            for operation, fields in operations.items():
+                result["resources"][resource_name][operation] = fields
+                self.stats.required_fields_exported += len(fields)
+            self.stats.resources_processed += 1
+
+        return result
+
+    def _export_enum_values(self) -> dict[str, Any]:
+        """Export enumeration/allowed values."""
+        enum_config = self.config.get("enum_values", {})
+        result: dict[str, Any] = {}
+
+        for enum_name, enum_def in enum_config.items():
+            result[enum_name] = {
+                "description": enum_def.get("description", ""),
+                "values": [],
+                "default": None,
+            }
+
+            for value_def in enum_def.get("values", []):
+                value_entry = {
+                    "value": value_def.get("value"),
+                    "description": value_def.get("description", ""),
+                }
+                result[enum_name]["values"].append(value_entry)
+                self.stats.enum_values_exported += 1
+
+                if value_def.get("is_default"):
+                    result[enum_name]["default"] = value_def.get("value")
+
+        return result
+
+    def _export_constraints(self) -> dict[str, Any]:
+        """Export type-level validation constraints."""
+        constraints_config = self.config.get("constraints", {})
+        result: dict[str, Any] = {
+            "type_defaults": {},
+        }
+
+        type_defaults = constraints_config.get("type_defaults", {})
+        for type_name, defaults in type_defaults.items():
+            # Filter out comment fields
+            result["type_defaults"][type_name] = {
+                k: v for k, v in defaults.items() if k != "comment"
+            }
+            self.stats.constraints_exported += 1
+
+        return result
+
+    def _export_patterns(self) -> list[dict[str, Any]]:
+        """Export pattern-based validation rules."""
+        constraints_config = self.config.get("constraints", {})
+        patterns = constraints_config.get("patterns", [])
+        result: list[dict[str, Any]] = []
+
+        for pattern_def in patterns:
+            pattern_entry = {
+                "pattern": pattern_def.get("pattern"),
+                "constraints": pattern_def.get("constraints", {}),
+                "confidence": pattern_def.get("confidence", 0.9),
+            }
+            # Optionally include comment for documentation
+            if "comment" in pattern_def:
+                pattern_entry["description"] = pattern_def["comment"]
+
+            result.append(pattern_entry)
+            self.stats.constraints_exported += 1
+
+        return result
+
+    def _export_server_defaults(self) -> dict[str, Any]:
+        """Export server-applied default values."""
+        defaults_config = self.config.get("server_defaults", {})
+        result: dict[str, Any] = {
+            "description": defaults_config.get("description", ""),
+            "resources": {},
+        }
+
+        resources = defaults_config.get("resources", {})
+        for resource_name, defaults in resources.items():
+            result["resources"][resource_name] = defaults
+            self.stats.server_defaults_exported += 1
+
+        return result
+
+    def _export_conditional_requirements(self) -> dict[str, Any]:
+        """Export conditional and mutually exclusive field requirements."""
+        conditional_config = self.config.get("conditional_requirements", {})
+        result: dict[str, Any] = {
+            "description": conditional_config.get("description", ""),
+            "resources": {},
+        }
+
+        resources = conditional_config.get("resources", {})
+        for resource_name, requirements in resources.items():
+            result["resources"][resource_name] = {
+                "mutually_exclusive": requirements.get("mutually_exclusive", []),
+                "conditional": requirements.get("conditional", []),
+            }
+            self.stats.conditional_requirements_exported += len(
+                requirements.get("mutually_exclusive", []),
+            ) + len(requirements.get("conditional", []))
+
+        return result
+
+    def _export_minimum_configurations(self) -> dict[str, Any]:
+        """Export minimum viable configurations."""
+        min_config = self.config.get("minimum_configurations", {})
+        result: dict[str, Any] = {
+            "description": min_config.get("description", ""),
+            "resources": {},
+        }
+
+        resources = min_config.get("resources", {})
+        for resource_name, config in resources.items():
+            result["resources"][resource_name] = {
+                "description": config.get("description", ""),
+            }
+
+            # Parse and include example JSON if present
+            example_json = config.get("example_json", "")
+            if example_json:
+                try:
+                    result["resources"][resource_name]["example"] = json.loads(example_json)
+                except json.JSONDecodeError as e:
+                    self.stats.warnings.append(
+                        f"Invalid JSON in minimum config for {resource_name}: {e}",
+                    )
+                    result["resources"][resource_name]["example_raw"] = example_json
+
+            self.stats.minimum_configs_exported += 1
+
+        return result
+
+    def _export_extension_mapping(self) -> dict[str, str]:
+        """Export OpenAPI extension field name mapping."""
+        return self.config.get("extension_mapping", {})
+
+    def get_stats(self) -> dict[str, Any]:
+        """Get export statistics.
+
+        Returns:
+            Dictionary with export metrics.
+        """
+        return self.stats.to_dict()
+
+
+def main() -> int:
+    """Main entry point for validation export."""
+    parser = argparse.ArgumentParser(
+        description="Export F5 XC validation schema to standalone JSON",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=Path("config/validation_schema.yaml"),
+        help="Path to validation schema config",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Output path (defaults to config export.output_path)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print output to stdout without writing file",
+    )
+
+    args = parser.parse_args()
+
+    try:
+        exporter = ValidationExporter(config_path=args.config)
+
+        # Determine output path
+        output_path = args.output
+        if not output_path and not args.dry_run:
+            output_path = Path(
+                exporter.config.get("export", {}).get(
+                    "output_path",
+                    "docs/specifications/api/validation.json",
+                ),
+            )
+
+        # Export validation spec
+        if args.dry_run:
+            validation_spec = exporter.export()
+            print(json.dumps(validation_spec, indent=2, ensure_ascii=False))
+            # Print stats to stderr in dry-run mode to keep stdout clean for piping
+            stats = exporter.get_stats()
+            print(f"Statistics: {json.dumps(stats, indent=2)}", file=sys.stderr)
+        else:
+            exporter.export(output_path)
+            print(f"Validation spec exported to: {output_path}")
+            # Print stats to stdout when writing to file
+            stats = exporter.get_stats()
+            print(f"Statistics: {json.dumps(stats, indent=2)}")
+
+        return 0
+
+    except FileNotFoundError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+    except Exception as e:
+        print(f"Error exporting validation: {e}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Add centralized validation schema for downstream consumers (CLI tools, Terraform providers, AI assistants). This introduces:

- **config/validation_schema.yaml**: Master validation configuration with required fields, enums, constraints, defaults, and minimum configs
- **scripts/utils/validation_exporter.py**: Standalone JSON export tool for downstream consumers
- **docs/VALIDATION_SPEC.md**: Comprehensive consumer documentation with Python, Go, and MCP integration examples

## Changes

- Modified `scripts/pipeline.py` to export validation.json as pipeline output
- Added `ValidationExporter` to `scripts/utils/__init__.py`
- New configuration file with validation rules
- New exporter implementation
- New consumer documentation

## Test Plan

- [x] Pre-commit hooks pass (formatting, linting)
- [ ] Pipeline completes successfully
- [ ] validation.json generated in output directory
- [ ] PR CI checks pass

Closes #461

🤖 Generated with [Claude Code](https://claude.com/claude-code)