### PR TITLE
docs: rewrite VALIDATION_SPEC.md as pure API reference

### DIFF
--- a/docs/VALIDATION_SPEC.md
+++ b/docs/VALIDATION_SPEC.md
@@ -1,24 +1,14 @@
 # F5 XC API Validation Specification
 
-Centralized validation specification for downstream projects consuming the F5 XC API.
+This document describes the structure and contents of the validation specification published by the f5xc-api-enriched project.
 
 ## Overview
 
-The f5xc-api-enriched project serves as the **single source of truth** for API validation constraints. Downstream projects (CLI tools, Terraform providers, AI assistants) should consume this centralized validation metadata rather than maintaining their own validation logic.
+The validation specification consolidates API validation constraints, default values, and configuration metadata into a single JSON file. This specification is generated from the enriched OpenAPI specs and published alongside them.
 
-### Why Centralized?
+**Publication location**: `docs/specifications/api/validation.json`
 
-| Factor | Centralized | Per-Project |
-|--------|-------------|-------------|
-| Consistency | All consumers validate the same way | Drift between implementations |
-| Maintenance | Update once, propagate everywhere | N implementations to update |
-| Discovery | Already have infrastructure | Each project rediscovers constraints |
-| Accuracy | Derived from actual API behavior | May diverge from real API |
-| Cost | One validation test suite | N test suites |
-
-## Validation Specification Format
-
-The validation specification is published as `docs/specifications/api/validation.json` and contains:
+## Specification Structure
 
 ```json
 {
@@ -38,13 +28,11 @@ The validation specification is published as `docs/specifications/api/validation
 }
 ```
 
-> **v2.1.0 Breaking Change**: The `defaults` section replaces the fragmented `server_defaults`, `oneof_defaults`, `ui_vs_server_defaults`, and `advanced_options_defaults` sections with a unified resource-centric structure.
-
 ## Sections
 
-### Required Fields
+### required_fields
 
-Specifies which fields are required for each operation (create, update, minimum_config).
+Specifies fields required for each operation type per resource.
 
 ```json
 {
@@ -63,36 +51,7 @@ Specifies which fields are required for each operation (create, update, minimum_
 }
 ```
 
-**Usage in downstream projects:**
-
-```python
-# Python example
-def validate_create(resource_type: str, data: dict) -> list[str]:
-    spec = load_validation_spec()
-    required = spec["required_fields"]["resources"].get(resource_type, {}).get("create", [])
-    errors = []
-    for field in required:
-        if not get_nested(data, field):
-            errors.append(f"Required field missing: {field}")
-    return errors
-```
-
-```go
-// Go example
-func ValidateCreate(resourceType string, data map[string]interface{}) []string {
-    spec := LoadValidationSpec()
-    required := spec.RequiredFields.Resources[resourceType].Create
-    var errors []string
-    for _, field := range required {
-        if !HasNestedField(data, field) {
-            errors = append(errors, fmt.Sprintf("Required field missing: %s", field))
-        }
-    }
-    return errors
-}
-```
-
-### Enum Values
+### enum_values
 
 Defines allowed values for constrained fields.
 
@@ -114,19 +73,7 @@ Defines allowed values for constrained fields.
 }
 ```
 
-**Usage:**
-
-```python
-def validate_enum(field_name: str, value: str, enum_type: str) -> bool:
-    spec = load_validation_spec()
-    enum_def = spec["enum_values"].get(enum_type)
-    if not enum_def:
-        return True  # No constraint
-    allowed = [v["value"] for v in enum_def["values"]]
-    return value in allowed
-```
-
-### Constraints
+### constraints
 
 Type-level validation defaults and pattern-based rules.
 
@@ -141,7 +88,7 @@ Type-level validation defaults and pattern-based rules.
 }
 ```
 
-### Patterns
+### patterns
 
 Field name pattern-based validation rules with confidence scores.
 
@@ -168,23 +115,9 @@ Field name pattern-based validation rules with confidence scores.
 }
 ```
 
-**Usage:**
+### defaults
 
-```python
-import re
-
-def get_field_constraints(field_name: str) -> dict:
-    spec = load_validation_spec()
-    constraints = {}
-    for pattern_def in spec["patterns"]:
-        if re.search(pattern_def["pattern"], field_name):
-            constraints.update(pattern_def["constraints"])
-    return constraints
-```
-
-### Defaults (Unified)
-
-All default values organized by resource type. Consolidates server-applied, recommended, advanced options, OneOf choices, and UI vs server discrepancies into a single resource-centric structure.
+All default values organized by resource type in a unified structure.
 
 ```json
 {
@@ -202,6 +135,17 @@ All default values organized by resource type. Consolidates server-applied, reco
           "unhealthy_threshold": 1,
           "healthy_threshold": 3,
           "jitter_percent": 30
+        },
+        "oneof_recommended": {
+          "health_check": "http_health_check"
+        },
+        "nested_recommended": {
+          "http_health_check": {
+            "path": "/",
+            "use_http2": false,
+            "expected_status_codes": ["200"],
+            "use_origin_server_name": {}
+          }
         }
       },
       "origin_pool": {
@@ -248,52 +192,19 @@ All default values organized by resource type. Consolidates server-applied, reco
 }
 ```
 
-**Default Categories:**
+#### Default Categories
 
 | Category | Description | Source |
 |----------|-------------|--------|
-| `server_applied` | Values API applies when fields omitted | Live API testing |
-| `recommended` | F5 XC UI pre-populated values | UI analysis |
-| `advanced_options` | Nested defaults within advanced_options | API discovery |
-| `oneof_choices` | Default OneOf selections | API behavior |
-| `ui_vs_server` | Where UI differs from API defaults | Comparative analysis |
+| `server_applied` | Values the API applies when fields are omitted | Live API testing |
+| `recommended` | F5 XC web console pre-populated values | UI analysis |
+| `advanced_options` | Nested defaults within advanced_options objects | API discovery |
+| `oneof_choices` | Default OneOf variant selections | API behavior |
+| `oneof_recommended` | Recommended OneOf variants | Console defaults |
+| `nested_recommended` | Recommended values for nested schemas | UI analysis |
+| `ui_vs_server` | Cases where UI defaults differ from API defaults | Comparative analysis |
 
-**Usage:**
-
-```python
-def get_default(resource: str, category: str, field: str = None) -> Any:
-    """Get default value from unified structure."""
-    spec = load_validation_spec()
-    defaults = spec.get("defaults", {}).get("resources", {}).get(resource, {})
-    category_data = defaults.get(category, {})
-    return category_data.get(field) if field else category_data
-
-# Examples:
-timeout = get_default("healthcheck", "recommended", "timeout")  # 3
-port = get_default("origin_pool", "recommended", "port")  # 443
-tls_choice = get_default("origin_pool", "oneof_choices", "tls_choice")  # "no_tls"
-lb_algo = get_default("origin_pool", "server_applied", "loadbalancer_algorithm")  # "ROUND_ROBIN"
-```
-
-**Usage in CLI help text:**
-
-```text
-$ xcsh origin-pool create --help
-
-DEFAULTS (server-applied):
-  --loadbalancer-algorithm  ROUND_ROBIN (if omitted)
-  --endpoint-selection      DISTRIBUTED (if omitted)
-
-RECOMMENDED VALUES:
-  --port                    443
-  --connection-timeout      2000ms
-
-ONEOF DEFAULTS:
-  --tls-choice              no_tls (disable TLS to origin)
-  --circuit-breaker-choice  default_circuit_breaker
-```
-
-### Conditional Requirements
+### conditional_requirements
 
 Mutually exclusive fields and conditional dependencies.
 
@@ -315,23 +226,7 @@ Mutually exclusive fields and conditional dependencies.
 }
 ```
 
-**Usage:**
-
-```python
-def validate_mutually_exclusive(resource_type: str, data: dict) -> list[str]:
-    spec = load_validation_spec()
-    requirements = spec["conditional_requirements"]["resources"].get(resource_type, {})
-    errors = []
-
-    for exclusion in requirements.get("mutually_exclusive", []):
-        present = [f for f in exclusion["fields"] if get_nested(data, f)]
-        if len(present) > 1:
-            errors.append(f"Mutually exclusive fields: {', '.join(present)}. {exclusion['reason']}")
-
-    return errors
-```
-
-### Minimum Configurations
+### minimum_configurations
 
 Minimum viable configurations with working examples.
 
@@ -356,196 +251,42 @@ Minimum viable configurations with working examples.
 
 ## OpenAPI Extension Mapping
 
-The enriched OpenAPI specs use these extensions to embed validation metadata:
+The enriched OpenAPI specs embed validation metadata using these extensions:
 
 | Extension | Purpose | Location |
 |-----------|---------|----------|
 | `x-f5xc-required-for` | Context-specific required fields | Schema properties |
 | `x-f5xc-server-default` | Marks server-applied defaults | Schema properties |
 | `x-f5xc-recommended-value` | Recommended default value | Schema properties |
+| `x-f5xc-recommended-oneof-variant` | Recommended OneOf variant | Schema definitions |
 | `x-f5xc-conditions` | Conditional requirements | Schema properties |
 | `x-f5xc-minimum-configuration` | Minimum config examples | Schema definitions |
 | `x-f5xc-validation` | Discovery-derived constraints | Schema properties |
 
-## Integration Examples
+## Data Access
 
-### CLI Tool (Python)
+### Publication URLs
 
-```python
-import json
-from pathlib import Path
+| Source | URL |
+|--------|-----|
+| GitHub Pages | `https://robinmordasiewicz.github.io/f5xc-api-enriched/specifications/api/validation.json` |
+| Raw GitHub | `https://raw.githubusercontent.com/robinmordasiewicz/f5xc-api-enriched/main/docs/specifications/api/validation.json` |
 
-class F5XCValidator:
-    def __init__(self, spec_path: str = "validation.json"):
-        with open(spec_path) as f:
-            self.spec = json.load(f)
+### Local Path
 
-    def validate_resource(self, resource_type: str, operation: str, data: dict) -> list[str]:
-        errors = []
-
-        # Check required fields
-        required = self.spec["required_fields"]["resources"].get(resource_type, {}).get(operation, [])
-        for field in required:
-            if not self._get_nested(data, field):
-                errors.append(f"Missing required field: {field}")
-
-        # Check enum values
-        errors.extend(self._validate_enums(resource_type, data))
-
-        # Check mutually exclusive fields
-        errors.extend(self._validate_mutual_exclusions(resource_type, data))
-
-        return errors
-
-    def get_defaults(self, resource_type: str, category: str = None) -> dict:
-        """Get defaults for a resource, optionally filtered by category."""
-        resource_defaults = self.spec["defaults"]["resources"].get(resource_type, {})
-        if category:
-            return resource_defaults.get(category, {})
-        return resource_defaults
-
-    def get_server_applied(self, resource_type: str) -> dict:
-        """Get server-applied defaults for a resource."""
-        return self.get_defaults(resource_type, "server_applied")
-
-    def get_recommended(self, resource_type: str) -> dict:
-        """Get recommended values for a resource."""
-        return self.get_defaults(resource_type, "recommended")
-
-    def get_minimum_config(self, resource_type: str) -> dict:
-        return self.spec["minimum_configurations"]["resources"].get(resource_type, {}).get("example", {})
-```
-
-### Terraform Provider (Go)
-
-```go
-package validation
-
-import (
-    "encoding/json"
-    "regexp"
-)
-
-type ValidationSpec struct {
-    RequiredFields           RequiredFieldsSpec           `json:"required_fields"`
-    EnumValues               map[string]EnumSpec          `json:"enum_values"`
-    Patterns                 []PatternSpec                `json:"patterns"`
-    Defaults                 DefaultsSpec                 `json:"defaults"`
-    ConditionalRequirements  ConditionalRequirementsSpec  `json:"conditional_requirements"`
-    MinimumConfigurations    MinimumConfigSpec            `json:"minimum_configurations"`
-}
-
-// DefaultsSpec represents the unified defaults structure
-type DefaultsSpec struct {
-    Description string                      `json:"description"`
-    Resources   map[string]ResourceDefaults `json:"resources"`
-}
-
-// ResourceDefaults contains all default categories for a resource
-type ResourceDefaults struct {
-    ServerApplied   map[string]interface{} `json:"server_applied,omitempty"`
-    Recommended     map[string]interface{} `json:"recommended,omitempty"`
-    AdvancedOptions map[string]interface{} `json:"advanced_options,omitempty"`
-    OneofChoices    map[string]string      `json:"oneof_choices,omitempty"`
-    UIVsServer      map[string]UIVsServer  `json:"ui_vs_server,omitempty"`
-}
-
-type UIVsServer struct {
-    UIDefault     string `json:"ui_default"`
-    ServerDefault string `json:"server_default"`
-    Note          string `json:"note,omitempty"`
-}
-
-func (v *ValidationSpec) ValidateCreate(resourceType string, data map[string]interface{}) []error {
-    var errors []error
-
-    if fields, ok := v.RequiredFields.Resources[resourceType]; ok {
-        for _, field := range fields.Create {
-            if !hasNestedField(data, field) {
-                errors = append(errors, fmt.Errorf("required field missing: %s", field))
-            }
-        }
-    }
-
-    return errors
-}
-
-func (v *ValidationSpec) GetFieldConstraints(fieldName string) map[string]interface{} {
-    constraints := make(map[string]interface{})
-
-    for _, pattern := range v.Patterns {
-        if matched, _ := regexp.MatchString(pattern.Pattern, fieldName); matched {
-            for k, v := range pattern.Constraints {
-                constraints[k] = v
-            }
-        }
-    }
-
-    return constraints
-}
-```
-
-### AI Assistant (MCP Server)
-
-```python
-class F5XCValidationTool:
-    """MCP tool for AI assistants to validate F5 XC configurations."""
-
-    def __init__(self):
-        self.spec = self._load_validation_spec()
-
-    def get_required_fields(self, resource_type: str, operation: str = "create") -> list[str]:
-        """Get required fields for a resource operation."""
-        return self.spec["required_fields"]["resources"].get(resource_type, {}).get(operation, [])
-
-    def get_allowed_values(self, enum_type: str) -> list[str]:
-        """Get allowed values for an enum field."""
-        enum_def = self.spec["enum_values"].get(enum_type, {})
-        return [v["value"] for v in enum_def.get("values", [])]
-
-    def get_minimum_example(self, resource_type: str) -> dict:
-        """Get minimum working configuration example."""
-        return self.spec["minimum_configurations"]["resources"].get(resource_type, {}).get("example", {})
-
-    def suggest_fix(self, resource_type: str, error_message: str) -> str:
-        """Suggest a fix based on validation error."""
-        # AI can use this to provide helpful suggestions
-        pass
-```
-
-## Fetching the Validation Spec
-
-The validation specification is published alongside the OpenAPI specs:
-
-```bash
-# Via GitHub Pages
-curl -O https://robinmordasiewicz.github.io/f5xc-api-enriched/specifications/api/validation.json
-
-# Via raw GitHub
-curl -O https://raw.githubusercontent.com/robinmordasiewicz/f5xc-api-enriched/main/docs/specifications/api/validation.json
-```
+After running the pipeline: `docs/specifications/api/validation.json`
 
 ## Versioning
 
-The validation spec follows semantic versioning:
+The validation spec follows semantic versioning in the `version` field:
 
-- **Major**: Breaking changes to structure or field names
-- **Minor**: New validation rules or resources added
-- **Patch**: Bug fixes or description updates
+| Change Type | Version Bump | Example |
+|-------------|--------------|---------|
+| Breaking structure changes | Major | Field renames, removed sections |
+| New validation rules or resources | Minor | New resource defaults |
+| Bug fixes or description updates | Patch | Typo corrections |
 
-Check the `version` field in the spec to ensure compatibility:
-
-```python
-spec = load_validation_spec()
-version = spec["version"]
-major = int(version.split(".")[0])
-if major < 2:
-    raise ValueError(f"Unsupported validation spec version: {version}. Requires v2.x for unified defaults.")
-```
-
-> **Migration Note**: v2.1.0 introduced the unified `defaults` structure. Code using `server_defaults`, `oneof_defaults`, `ui_vs_server_defaults`, or `advanced_options_defaults` must be updated to use `defaults.resources.<resource>.<category>`.
-
-## Reconciliation Strategy
+## Reconciliation Priority
 
 When multiple sources provide constraints, the reconciliation priority is:
 
@@ -553,29 +294,17 @@ When multiple sources provide constraints, the reconciliation priority is:
 2. **Discovery** - Constraints from live API discovery
 3. **Inferred** - Constraints from pattern matching (lowest priority)
 
-This ensures manually curated constraints take precedence while still benefiting from automated discovery.
-
-## What Downstream Projects Should Own
-
-While validation rules are centralized, downstream projects still own:
-
-| Project | Project-Specific Concerns |
-|---------|---------------------------|
-| **CLI Tools** | Flag parsing, shell completion, interactive prompts, help text formatting |
-| **Terraform** | State management, plan/apply logic, provider-specific schema types |
-| **AI Assistants** | Context window management, prompt optimization, response formatting |
-| **All** | Network timeouts, retry logic, authentication, error display |
-
-## Contributing
-
-To add or update validation rules:
-
-1. Edit `config/validation_schema.yaml`
-2. Run the pipeline to regenerate `validation.json`
-3. Submit a PR with justification for the change
-
 ## Related Documentation
 
+- [Healthcheck Enhancements](HEALTHCHECK_ENHANCEMENTS.md) - Healthcheck schema enrichments
+- [Origin Pool Enhancements](ORIGINPOOL_ENHANCEMENTS.md) - Origin pool schema enrichments
 - [CLAUDE.md](../CLAUDE.md) - AI assistant instructions
 - [DEVELOPMENT.md](DEVELOPMENT.md) - Developer guide
-- [config/validation_schema.yaml](../config/validation_schema.yaml) - Source configuration
+
+## Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 2.1.2 | 2026-01-18 | Rewritten as pure API reference; added oneof_recommended and nested_recommended categories |
+| 2.1.0 | 2026-01-18 | Unified defaults structure replacing fragmented sections |
+| 2.0.0 | 2026-01-15 | Initial validation specification |


### PR DESCRIPTION
## Summary

Rewrites VALIDATION_SPEC.md following the same pure API reference pattern established in HEALTHCHECK_ENHANCEMENTS.md.

## Changes

- Remove downstream implementation examples (Python, Go, CLI usage code)
- Remove prescriptive language and "Why Centralized" advocacy section
- Keep JSON structure examples showing actual spec format
- Add Default Categories table with clear descriptions
- Add `oneof_recommended` and `nested_recommended` to defaults structure documentation
- Establish consistent documentation pattern across enrichment docs

## Removed Content

| Section | Reason |
|---------|--------|
| "Why Centralized?" table | Advocacy, not reference |
| Python/Go code examples | Downstream implementation |
| CLI help text example | Downstream implementation |
| "What Downstream Projects Should Own" | Prescriptive guidance |
| "Contributing" section | Process, not reference |

## Test plan

- [x] No prescriptive language (should/must/recommend)
- [x] No downstream code examples
- [x] JSON examples show actual spec structure
- [x] Links to related docs valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)