### PR TITLE
feat: add origin server type enums and align config structure

### DIFF
--- a/config/discovered_defaults.yaml
+++ b/config/discovered_defaults.yaml
@@ -148,51 +148,42 @@ resources:
     # =========================================================================
     # Nested defaults for advanced_options (via $ref resolution)
     # These are applied to origin_poolOriginPoolAdvancedOptions schema
+    # Structure matches healthcheck pattern with defaults/recommended sub-keys
     # =========================================================================
     nested:
       advanced_options:
-        # UI Option 7: Connection Timeout (milliseconds)
-        connection_timeout: 2000
-        # UI Option 8: HTTP Idle Timeout (milliseconds)
-        http_idle_timeout: 300000
-        # UI Option 3: Health check port - default uses endpoint port
-        same_as_endpoint_port: {}
-        # UI Option 9: Circuit breaker - use default settings
-        default_circuit_breaker: {}
-        # UI Option 10: Outlier detection - disabled
-        disable_outlier_detection: {}
-        # UI Option 11: Panic threshold - none
-        no_panic_threshold: {}
-        # UI Option 12: Subset load balancing - disabled
-        disable_subsets: {}
-        # UI Option 13: HTTP protocol - auto negotiation
-        auto_http_config: {}
-        # UI Option 14: Proxy protocol - disabled
-        disable_proxy_protocol: {}
-        # UI Option 15: LB source IP persistence - disabled
-        disable_lb_source_ip_persistance: {}
+        # Server-applied defaults (what server sets when fields are omitted)
+        defaults:
+          # UI Option 3: Health check port - default uses endpoint port
+          same_as_endpoint_port: {}
+          # UI Option 9: Circuit breaker - use default settings
+          default_circuit_breaker: {}
+          # UI Option 10: Outlier detection - disabled
+          disable_outlier_detection: {}
+          # UI Option 11: Panic threshold - none
+          no_panic_threshold: {}
+          # UI Option 12: Subset load balancing - disabled
+          disable_subsets: {}
+          # UI Option 13: HTTP protocol - auto negotiation
+          auto_http_config: {}
+          # UI Option 14: Proxy protocol - disabled
+          disable_proxy_protocol: {}
+          # UI Option 15: LB source IP persistence - disabled
+          disable_lb_source_ip_persistance: {}
+        # Recommended values for UI/CLI/AI assistants
+        # These match F5 XC web interface pre-populated values
+        recommended:
+          # UI Option 7: Connection Timeout (milliseconds)
+          connection_timeout: 2000
+          # UI Option 8: HTTP Idle Timeout (milliseconds)
+          http_idle_timeout: 300000
 
     # =========================================================================
-    # advanced_options_defaults (for validation.json export)
-    # Duplicate of nested.advanced_options for validation_exporter.py
+    # OneOf field recommended selections
+    # Maps OneOf group names to their recommended variant for UI/CLI/AI assistants
+    # Renamed from oneof_defaults to align with healthcheck pattern
     # =========================================================================
-    advanced_options_defaults:
-      connection_timeout: 2000
-      http_idle_timeout: 300000
-      same_as_endpoint_port: {}
-      default_circuit_breaker: {}
-      disable_outlier_detection: {}
-      no_panic_threshold: {}
-      disable_subsets: {}
-      auto_http_config: {}
-      disable_proxy_protocol: {}
-      disable_lb_source_ip_persistance: {}
-
-    # =========================================================================
-    # OneOf field default selections
-    # Maps OneOf group names to their default selection when omitted
-    # =========================================================================
-    oneof_defaults:
+    oneof_recommended:
       # UI Option 1: Port Configuration
       port_choice: "port"  # Most common is explicit port
       # UI Option 2: Connection Pool Reuse
@@ -259,6 +250,62 @@ resources:
         ui_default: "LB_OVERRIDE"
         server_default: "ROUND_ROBIN"
         note: "UI pre-selects LB_OVERRIDE but server applies ROUND_ROBIN if omitted"
+
+    # =========================================================================
+    # Origin Server Types
+    # Constrained values for origin_servers[].type selection
+    # =========================================================================
+    origin_server_types:
+      # OneOf recommended variant for origin server type
+      oneof_recommended:
+        origin_server_type: "public_name"  # Default in UI
+
+      # Constrained values (enums)
+      enums:
+        origin_server_type:
+          description: "Type of origin server to add to the pool"
+          values:
+            - value: "public_name"
+              description: "Specify origin server with public DNS name"
+              is_default: true
+              nested_fields:
+                - dns_name (required)
+            - value: "public_ip"
+              description: "Specify origin server with public IP"
+              nested_fields:
+                - ip (required, IPv4)
+            # TODO: Site-dependent types require "site" logic development
+            # See: docs/ORIGINPOOL_ENHANCEMENTS.md for full specification
+            - value: "private_ip"
+              description: "Specify origin server with private/public IP and site information"
+              status: "TODO - requires site logic"
+            - value: "private_name"
+              description: "Specify origin server with DNS name and site information"
+              status: "TODO - requires site logic"
+            - value: "k8s_service"
+              description: "Specify origin server with K8s service name and site information"
+              status: "TODO - requires site logic"
+            - value: "consul_service"
+              description: "Specify origin server with HashiCorp Consul service name and site"
+              status: "TODO - requires site logic"
+
+      # Completed type configurations
+      nested:
+        public_name:
+          recommended:
+            dns_name: ""  # Required, user must provide
+        public_ip:
+          oneof_recommended:
+            public_ip_choice: "ip"  # IPv4 default
+          recommended:
+            ip: ""  # Required, user must provide (e.g., "8.8.8.8")
+
+      # TODO: Site-dependent nested configurations
+      # These require completion after "site" development sprint:
+      # - private_ip: ip, site_locator, network_choice, snat_pool
+      # - private_name: dns_name, site_locator, network_choice, snat_pool
+      # - k8s_service: service_name, site_locator, network_choice
+      # - consul_service: service_name, site_locator, network_choice
 
 # Documentation for adding new defaults:
 # 1. Create resource in F5 XC with minimal/empty spec via API

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -304,6 +304,16 @@ rules:
 
 The enrichment pipeline uses vendor extensions to embed validation and default value metadata.
 
+### Extension Categories
+
+| Extension | Meaning | Implication |
+|-----------|---------|-------------|
+| `x-f5xc-server-default` | The F5 XC API server applies this value when the field is omitted | Field is optional; omitting it produces the documented default behavior |
+| `x-f5xc-recommended-value` | The F5 XC web console pre-populates this value for new resources | Field has no server default but this value represents typical configuration |
+| `x-f5xc-recommended-oneof-variant` | The F5 XC console pre-selects this OneOf variant | Identifies the typical choice when multiple mutually exclusive options exist |
+
+**Key distinction**: Server-applied defaults are handled by the API automatically. Recommended values are suggestions that require explicit inclusion if desired.
+
 ### Required Field Extensions
 
 | Extension | Source | Purpose |
@@ -323,6 +333,44 @@ The enrichment pipeline uses vendor extensions to embed validation and default v
 | `x-f5xc-server-default: true` | Marks server-applied defaults |
 | `x-f5xc-recommended-value` | F5 XC console pre-populated value |
 | `x-f5xc-recommended-oneof-variant` | Recommended OneOf variant |
+
+#### x-f5xc-server-default
+
+**Type**: `boolean`
+
+When `true`, indicates the accompanying `default` value is enforced by the F5 XC API server. Fields with this extension can be safely omitted from API requests—the server applies the default automatically.
+
+```yaml
+use_http2:
+  type: boolean
+  default: false
+  x-f5xc-server-default: true
+```
+
+#### x-f5xc-recommended-value
+
+**Type**: `any` (matches field type)
+
+Specifies a value that the F5 XC web console uses as a pre-populated default. This value is not server-enforced but represents the typical starting configuration for new resources created via the console.
+
+```yaml
+timeout:
+  type: integer
+  x-f5xc-recommended-value: 3
+```
+
+#### x-f5xc-recommended-oneof-variant
+
+**Type**: `object` (map of group name to variant name)
+
+For schemas with mutually exclusive field groups, identifies which variant is the default or most common choice. The key is the OneOf group name and the value is the recommended variant field name.
+
+```yaml
+healthcheckCreateSpecType:
+  type: object
+  x-f5xc-recommended-oneof-variant:
+    health_check: "http_health_check"
+```
 
 ### Validation Rule Implications
 

--- a/docs/HEALTHCHECK_ENHANCEMENTS.md
+++ b/docs/HEALTHCHECK_ENHANCEMENTS.md
@@ -1,17 +1,6 @@
 # Healthcheck Schema Enrichments
 
-This document describes the enrichment metadata applied to healthcheck-related schemas in the F5 XC API specifications.
-
-## Overview
-
-The enriched specifications contain two categories of default value metadata:
-
-| Extension | Meaning | Implication |
-|-----------|---------|-------------|
-| `x-f5xc-server-default` | The F5 XC API server applies this value when the field is omitted | Field is optional; omitting it produces the documented default behavior |
-| `x-f5xc-recommended-value` | The F5 XC web console pre-populates this value for new resources | Field has no server default but this value represents typical configuration |
-
-**Key distinction**: Server-applied defaults are handled by the API automatically. Recommended values are suggestions that require explicit inclusion if desired.
+Enrichment metadata for healthcheck-related schemas. See [OpenAPI Extensions](DEVELOPMENT.md#openapi-extensions) for extension definitions.
 
 ## Enriched Schemas
 
@@ -27,7 +16,7 @@ Additionally, the nested schema `healthcheckHttpHealthCheck` contains enrichment
 
 ## Server-Applied Defaults
 
-Fields marked with `x-f5xc-server-default: true` have their `default` value applied by the F5 XC API server when omitted from requests. These fields are effectively optional—the API produces consistent behavior whether the field is explicitly set to the default value or omitted entirely.
+Fields marked with `x-f5xc-server-default: true` have their `default` value applied by the F5 XC API server when omitted from requests.
 
 ### Top-Level Fields
 
@@ -48,7 +37,7 @@ Fields marked with `x-f5xc-server-default: true` have their `default` value appl
 
 ## Recommended Values
 
-Fields marked with `x-f5xc-recommended-value` indicate values that the F5 XC web console pre-populates when creating new resources. Unlike server-applied defaults, these values are not automatically applied by the API—they represent typical configurations that align with console behavior. These values are derived from F5 XC UI observation and provide a baseline for generating configurations that match console-created resources.
+Fields marked with `x-f5xc-recommended-value` indicate values that the F5 XC web console pre-populates when creating new resources.
 
 ### Top-Level Fields
 
@@ -71,60 +60,14 @@ Fields marked with `x-f5xc-recommended-value` indicate values that the F5 XC web
 
 ## OneOf Variant Recommendations
 
-Schemas containing mutually exclusive field groups (OneOf) include `x-f5xc-recommended-oneof-variant` to indicate which variant is most commonly used. This metadata identifies the typical choice when multiple options exist, based on F5 XC console defaults and common usage patterns.
-
 | Schema | OneOf Group | Recommended Variant | Description |
 |--------|-------------|---------------------|-------------|
 | `healthcheckCreateSpecType` | `health_check` | `http_health_check` | HTTP health check type |
 | `healthcheckReplaceSpecType` | `health_check` | `http_health_check` | HTTP health check type |
 
-## OpenAPI Extensions Reference
-
-These vendor extensions are added to the standard OpenAPI schema to convey F5 XC-specific default behavior.
-
-### x-f5xc-server-default
-
-**Type**: `boolean`
-
-When `true`, indicates the accompanying `default` value is enforced by the F5 XC API server. Fields with this extension can be safely omitted from API requests—the server applies the default automatically.
-
-```yaml
-use_http2:
-  type: boolean
-  default: false
-  x-f5xc-server-default: true
-```
-
-### x-f5xc-recommended-value
-
-**Type**: `any` (matches field type)
-
-Specifies a value that the F5 XC web console uses as a pre-populated default. This value is not server-enforced but represents the typical starting configuration for new resources created via the console.
-
-```yaml
-timeout:
-  type: integer
-  x-f5xc-recommended-value: 3
-```
-
-### x-f5xc-recommended-oneof-variant
-
-**Type**: `object` (map of group name to variant name)
-
-For schemas with mutually exclusive field groups, identifies which variant is the default or most common choice. The key is the OneOf group name and the value is the recommended variant field name.
-
-```yaml
-healthcheckCreateSpecType:
-  type: object
-  x-f5xc-recommended-oneof-variant:
-    health_check: "http_health_check"
-```
-
 ## Data Access
 
 ### OpenAPI Specifications
-
-Enriched schemas are located in:
 
 | File | Content |
 |------|---------|
@@ -133,9 +76,7 @@ Enriched schemas are located in:
 
 ### validation.json Structure
 
-Healthcheck defaults are consolidated at:
-
-```
+```text
 defaults.resources.healthcheck
 ├── server_applied      # Fields with x-f5xc-server-default: true
 ├── recommended         # Fields with x-f5xc-recommended-value
@@ -145,16 +86,17 @@ defaults.resources.healthcheck
 
 ## Related Documentation
 
+- [Development Guide - OpenAPI Extensions](DEVELOPMENT.md#openapi-extensions) - Extension definitions and usage
 - [Validation Specification](VALIDATION_SPEC.md) - validation.json format and structure
 - [Origin Pool Enhancements](ORIGINPOOL_ENHANCEMENTS.md) - Origin pool schema enrichments
-- [Minimum Configuration](/config/minimum_configs.yaml) - Resource configuration definitions
 
 ## Changelog
 
 | Version | Date | Changes |
 |---------|------|---------|
-| 2.1.2 | 2026-01-18 | Rewritten as pure API reference; removed downstream examples and prescriptive language |
-| 2.1.1 | 2026-01-18 | Added nested recommended values, OneOf recommended variants, `x-f5xc-recommended-oneof-variant` extension |
+| 2.1.3 | 2026-01-18 | Consolidated global extension docs to DEVELOPMENT.md; resource-specific data only |
+| 2.1.2 | 2026-01-18 | Rewritten as pure API reference; removed downstream examples |
+| 2.1.1 | 2026-01-18 | Added nested recommended values, OneOf recommended variants |
 | 2.1.0 | 2026-01-18 | Added unified defaults structure in validation.json |
-| 2.0.30 | 2026-01-16 | Added nested defaults for `$ref` schemas (healthcheckHttpHealthCheck) |
+| 2.0.30 | 2026-01-16 | Added nested defaults for `$ref` schemas |
 | 2.0.29 | 2026-01-17 | Initial healthcheck defaults |

--- a/docs/ORIGINPOOL_ENHANCEMENTS.md
+++ b/docs/ORIGINPOOL_ENHANCEMENTS.md
@@ -1,30 +1,27 @@
-# Origin Pool API Enhancements
+# Origin Pool Schema Enrichments
 
-Comprehensive documentation of origin_pool validation discoveries for downstream projects (CLI tools, Terraform providers, AI assistants).
+Enrichment metadata for origin_pool-related schemas. See [OpenAPI Extensions](DEVELOPMENT.md#openapi-extensions) for extension definitions.
 
-## Overview
+## Enriched Schemas
 
-This document captures all validation constraints, default values, and behavioral patterns discovered through systematic API testing of the F5 XC origin_pool resource. These discoveries enable downstream projects to:
+### Pattern
 
-- Generate valid configurations without trial-and-error
-- Provide accurate help text and documentation
-- Warn users about UI vs Server default discrepancies
-- Implement intelligent defaults matching server behavior
+All schemas matching `origin_pool.*SpecType` receive enrichments:
 
----
+- `origin_poolCreateSpecType`
+- `origin_poolReplaceSpecType`
+- `origin_poolGetSpecType`
 
-## Quick Reference
-
-### Required Fields
+## Required Fields
 
 | Field | Required For | Notes |
 |-------|--------------|-------|
-| `metadata.name` | All operations | 1-63 chars, lowercase alphanumeric |
-| `metadata.namespace` | All operations | Must exist in tenant |
-| `spec.origin_servers` | Create | Minimum 1 item required |
-| `spec.port` | Create | 1-65535, no default applied |
+| `metadata.name` | All operations | 1-63 chars, lowercase alphanumeric, pattern: `^[a-z0-9]([-a-z0-9]*[a-z0-9])?$` |
+| `metadata.namespace` | All operations | Namespace identifier |
+| `spec.origin_servers` | Create | Minimum 1 item |
+| `spec.port` | Create | 1-65535, no server default |
 
-### Minimum Viable Configuration
+## Minimum Viable Configuration
 
 ```json
 {
@@ -45,22 +42,113 @@ This document captures all validation constraints, default values, and behaviora
 }
 ```
 
----
+## Server-Applied Defaults
 
-## All 15 UI Configuration Options
+Fields marked with `x-f5xc-server-default: true` have their `default` value applied by the F5 XC API server when omitted from requests.
 
-The F5 XC web console presents 15 configuration options for origin pools. Here's how they map to API fields:
+### Top-Level Fields
 
-| # | UI Label | API Field Path | Type | Default |
-|---|----------|----------------|------|---------|
+| Field | Default Value | Type | Description |
+|-------|---------------|------|-------------|
+| `no_tls` | `{}` | object | TLS to origin disabled |
+| `healthcheck` | `[]` | array | No health checks configured |
+| `loadbalancer_algorithm` | `ROUND_ROBIN` | enum | Round-robin load balancing |
+| `endpoint_selection` | `DISTRIBUTED` | enum | Use all endpoints (local + remote) |
+
+### advanced_options Defaults
+
+When `advanced_options` is not specified, the server behaves as if these values were set:
+
+| Field | Default Value | Type | Description |
+|-------|---------------|------|-------------|
+| `connection_timeout` | `2000` | integer | Connection timeout in milliseconds |
+| `http_idle_timeout` | `300000` | integer | HTTP idle timeout in milliseconds (5 min) |
+| `same_as_endpoint_port` | `{}` | object | Health check uses endpoint port |
+| `default_circuit_breaker` | `{}` | object | Default circuit breaker settings |
+| `disable_outlier_detection` | `{}` | object | Outlier detection disabled |
+| `no_panic_threshold` | `{}` | object | No panic threshold |
+| `disable_subsets` | `{}` | object | Subset load balancing disabled |
+| `auto_http_config` | `{}` | object | Automatic HTTP protocol negotiation |
+| `disable_proxy_protocol` | `{}` | object | Proxy protocol disabled |
+| `disable_lb_source_ip_persistance` | `{}` | object | LB source IP persistence disabled |
+
+### Nested Object Defaults
+
+| Path | Default Value | Description |
+|------|---------------|-------------|
+| `origin_servers[].labels` | `{}` | Empty labels object |
+| `origin_servers[].public_name.refresh_interval` | `0` | Use system default DNS refresh |
+
+## UI vs Server Default Discrepancies
+
+The F5 XC web UI pre-selects different values than what the API applies when fields are omitted.
+
+| Field | UI Pre-Selected | Server Applied | Note |
+|-------|-----------------|----------------|------|
+| `loadbalancer_algorithm` | `LB_OVERRIDE` | `ROUND_ROBIN` | UI-created and API-created resources differ when field is omitted |
+
+## Enum Values
+
+### loadbalancer_algorithm
+
+| Value | Description | Notes |
+|-------|-------------|-------|
+| `ROUND_ROBIN` | Each healthy endpoint selected in round-robin order | Server default |
+| `LEAST_REQUEST` | Endpoint with fewest active requests selected | |
+| `RING_HASH` | Consistent hashing using ring hash of endpoint names | |
+| `RANDOM` | Random healthy endpoint selection | |
+| `LB_OVERRIDE` | Hash policy inherited from parent load balancer | UI default |
+
+### endpoint_selection
+
+| Value | Description | Notes |
+|-------|-------------|-------|
+| `DISTRIBUTED` | Consider both remote and local endpoints | Server default |
+| `LOCAL_ONLY` | Only local endpoints used | |
+| `LOCAL_PREFERRED` | Prefer local, fall back to remote if unavailable | |
+
+## OneOf Field Groups
+
+Mutually exclusive field groups. Only ONE field from each group can be specified:
+
+| Group | Fields | Server Default |
+|-------|--------|----------------|
+| Port Configuration | `port`, `automatic_port`, `lb_port` | `port` (explicit) |
+| TLS to Origin | `no_tls`, `use_tls` | `no_tls` |
+| Health Check Port | `same_as_endpoint_port`, `health_check_port` | `same_as_endpoint_port` |
+| Circuit Breaker | `default_circuit_breaker`, `disable_circuit_breaker`, `circuit_breaker` | `default_circuit_breaker` |
+| Outlier Detection | `disable_outlier_detection`, `outlier_detection` | `disable_outlier_detection` |
+| Panic Threshold | `no_panic_threshold`, `panic_threshold` | `no_panic_threshold` |
+| Subset LB | `disable_subsets`, `enable_subsets` | `disable_subsets` |
+| HTTP Protocol | `auto_http_config`, `http1_config`, `http2_options` | `auto_http_config` |
+| Proxy Protocol | `disable_proxy_protocol`, `proxy_protocol_v1`, `proxy_protocol_v2` | `disable_proxy_protocol` |
+| LB Source IP | `disable_lb_source_ip_persistance`, `enable_lb_source_ip_persistance` | `disable_lb_source_ip_persistance` |
+| Connection Pool | `enable_conn_pool_reuse`, `disable_conn_pool_reuse` | `enable_conn_pool_reuse` |
+
+## Field Constraints
+
+| Field | Type | Constraint |
+|-------|------|------------|
+| `spec.port` | integer | 1-65535 |
+| `spec.advanced_options.connection_timeout` | integer | 0-1,800,000 ms |
+| `spec.advanced_options.http_idle_timeout` | integer | 0-600,000 ms |
+| `spec.advanced_options.panic_threshold` | integer | 0-100 (percentage) |
+| `metadata.name` | string | 1-63 chars, pattern: `^[a-z0-9]([-a-z0-9]*[a-z0-9])?$` |
+
+## UI Configuration Options
+
+The F5 XC web console presents 15 configuration options for origin pools:
+
+| # | UI Label | API Field Path | Type | Server Default |
+|---|----------|----------------|------|----------------|
 | 1 | Origin Server Port | `spec.[port\|automatic_port\|lb_port]` | OneOf | `port` (explicit) |
 | 2 | Connection Pool Reuse | `spec.[enable_conn_pool_reuse\|disable_conn_pool_reuse]` | OneOf | `enable_conn_pool_reuse` |
 | 3 | Health Check Port | `spec.advanced_options.[same_as_endpoint_port\|health_check_port]` | OneOf | `same_as_endpoint_port` |
-| 4 | LoadBalancer Algorithm | `spec.loadbalancer_algorithm` | Enum | `ROUND_ROBIN` ⚠️ |
-| 5 | Endpoint Selection | `spec.endpoint_selection` | Enum | `DISTRIBUTED` |
+| 4 | LoadBalancer Algorithm | `spec.loadbalancer_algorithm` | enum | `ROUND_ROBIN` |
+| 5 | Endpoint Selection | `spec.endpoint_selection` | enum | `DISTRIBUTED` |
 | 6 | TLS to Origin | `spec.[no_tls\|use_tls]` | OneOf | `no_tls` |
-| 7 | Connection Timeout | `spec.advanced_options.connection_timeout` | Integer | 2000 ms |
-| 8 | HTTP Idle Timeout | `spec.advanced_options.http_idle_timeout` | Integer | 300000 ms |
+| 7 | Connection Timeout | `spec.advanced_options.connection_timeout` | integer | 2000 ms |
+| 8 | HTTP Idle Timeout | `spec.advanced_options.http_idle_timeout` | integer | 300000 ms |
 | 9 | Circuit Breaker | `spec.advanced_options.[default_circuit_breaker\|disable_circuit_breaker\|circuit_breaker]` | OneOf | `default_circuit_breaker` |
 | 10 | Outlier Detection | `spec.advanced_options.[disable_outlier_detection\|outlier_detection]` | OneOf | `disable_outlier_detection` |
 | 11 | Panic Threshold | `spec.advanced_options.[no_panic_threshold\|panic_threshold]` | OneOf | `no_panic_threshold` |
@@ -69,399 +157,101 @@ The F5 XC web console presents 15 configuration options for origin pools. Here's
 | 14 | Proxy Protocol | `spec.advanced_options.[disable_proxy_protocol\|proxy_protocol_v1\|proxy_protocol_v2]` | OneOf | `disable_proxy_protocol` |
 | 15 | LB Source IP Persistence | `spec.advanced_options.[disable_lb_source_ip_persistance\|enable_lb_source_ip_persistance]` | OneOf | `disable_lb_source_ip_persistance` |
 
-⚠️ **Note**: Option 4 (LoadBalancer Algorithm) has a UI vs Server default discrepancy - see below.
+## Data Access
 
----
+### OpenAPI Specifications
 
-## Server-Applied Defaults
+| File | Content |
+|------|---------|
+| `docs/specifications/api/virtual.json` | `origin_poolCreateSpecType`, `origin_poolReplaceSpecType`, `origin_poolGetSpecType` |
+| `docs/specifications/api/openapi.json` | Merged specification with all schemas |
 
-When fields are omitted, the F5 XC API automatically applies these values:
-
-### Top-Level Spec Defaults
-
-| Field | Server Default | Description |
-|-------|----------------|-------------|
-| `no_tls` | `{}` | TLS to origin disabled |
-| `healthcheck` | `[]` | No health checks configured |
-| `loadbalancer_algorithm` | `ROUND_ROBIN` | Round-robin load balancing |
-| `endpoint_selection` | `DISTRIBUTED` | Use all endpoints (local + remote) |
-
-### Advanced Options Defaults
-
-When `advanced_options` is not specified, the server behaves as if these values were set:
-
-| Field | Default Value | Description |
-|-------|---------------|-------------|
-| `connection_timeout` | 2000 | Connection timeout in milliseconds |
-| `http_idle_timeout` | 300000 | HTTP idle timeout in milliseconds (5 min) |
-| `same_as_endpoint_port` | `{}` | Health check uses endpoint port |
-| `default_circuit_breaker` | `{}` | Default circuit breaker settings |
-| `disable_outlier_detection` | `{}` | Outlier detection disabled |
-| `no_panic_threshold` | `{}` | No panic threshold |
-| `disable_subsets` | `{}` | Subset load balancing disabled |
-| `auto_http_config` | `{}` | Automatic HTTP protocol negotiation |
-| `disable_proxy_protocol` | `{}` | Proxy protocol disabled |
-| `disable_lb_source_ip_persistance` | `{}` | LB source IP persistence disabled |
-
-### Nested Object Defaults
-
-| Path | Default | Description |
-|------|---------|-------------|
-| `origin_servers[].labels` | `{}` | Empty labels object |
-| `origin_servers[].public_name.refresh_interval` | `0` | Use system default DNS refresh |
-
----
-
-## ⚠️ UI vs Server Default Discrepancy
-
-**Critical Discovery**: The F5 XC web UI pre-selects different values than what the API applies when fields are omitted.
-
-| Field | UI Pre-Selected | Server Applied | Impact |
-|-------|-----------------|----------------|--------|
-| `loadbalancer_algorithm` | `LB_OVERRIDE` | `ROUND_ROBIN` | Configurations created via UI behave differently than API-created ones with omitted field |
-
-### Implications for Downstream Projects
-
-**CLI Tools**: Display warning when `loadbalancer_algorithm` is omitted:
+### validation.json Structure
 
 ```text
-⚠️  Note: Server will apply 'ROUND_ROBIN' (UI shows 'LB_OVERRIDE' by default)
+defaults.resources.origin_pool
+├── server_applied      # Fields with x-f5xc-server-default: true
+├── recommended         # Fields with x-f5xc-recommended-value
+├── advanced_options    # Nested advanced_options defaults
+├── oneof_choices       # OneOf default selections
+└── ui_vs_server        # UI vs server discrepancies
 ```
 
-**Terraform Providers**: Consider making this field required or showing drift warnings.
+## Origin Server Types
 
-**AI Assistants**: Always explicitly set `loadbalancer_algorithm` to avoid ambiguity.
+Origin servers can be specified using different type variants. The type determines what additional fields are required.
 
----
+### Implemented Types
 
-## Enum Values
+| Type | Description | Required Fields | Status |
+|------|-------------|-----------------|--------|
+| `public_name` | Origin server with public DNS name | `dns_name` | ✅ Complete |
+| `public_ip` | Origin server with public IP address | `ip` (IPv4) | ✅ Complete |
 
-### loadbalancer_algorithm
+### Example: public_name
 
-| Value | Description | Notes |
-|-------|-------------|-------|
-| `ROUND_ROBIN` | Each healthy endpoint selected in round-robin order | **Server default** |
-| `LEAST_REQUEST` | Endpoint with fewest active requests selected | |
-| `RING_HASH` | Consistent hashing using ring hash of endpoint names | |
-| `RANDOM` | Random healthy endpoint selection | |
-| `LB_OVERRIDE` | Hash policy inherited from parent load balancer | **UI default** |
-
-### endpoint_selection
-
-| Value | Description | Notes |
-|-------|-------------|-------|
-| `DISTRIBUTED` | Consider both remote and local endpoints | **Default** |
-| `LOCAL_ONLY` | Only local endpoints used | |
-| `LOCAL_PREFERRED` | Prefer local, fall back to remote if unavailable | |
-
----
-
-## OneOf Patterns (Mutually Exclusive Fields)
-
-Origin pool uses OneOf patterns extensively. Only ONE field from each group can be specified:
-
-### Port Configuration (Option 1)
-
-```yaml
-# Choose exactly one:
-spec.port: 443                    # Explicit port number (1-65535)
-spec.automatic_port: {}           # Port automatically assigned
-spec.lb_port: {}                  # Use load balancer port
-```
-
-### TLS to Origin (Option 6)
-
-```yaml
-# Choose exactly one:
-spec.no_tls: {}                   # Disable TLS (default)
-spec.use_tls:                     # Enable TLS with configuration
-  sni: "backend.example.com"
-  volterra_trusted_ca: {}
-```
-
-### Circuit Breaker (Option 9)
-
-```yaml
-# Choose exactly one:
-spec.advanced_options.default_circuit_breaker: {}     # Use defaults
-spec.advanced_options.disable_circuit_breaker: {}     # Disable
-spec.advanced_options.circuit_breaker:                # Custom config
-  max_connections: 1000
-  max_pending_requests: 100
-```
-
-### HTTP Protocol (Option 13)
-
-```yaml
-# Choose exactly one:
-spec.advanced_options.auto_http_config: {}     # Auto-negotiate (default)
-spec.advanced_options.http1_config: {}         # HTTP/1.x only
-spec.advanced_options.http2_options: {}        # HTTP/2 options
-```
-
-### Proxy Protocol (Option 14)
-
-```yaml
-# Choose exactly one:
-spec.advanced_options.disable_proxy_protocol: {}   # Disabled (default)
-spec.advanced_options.proxy_protocol_v1: {}        # Proxy Protocol v1
-spec.advanced_options.proxy_protocol_v2: {}        # Proxy Protocol v2
-```
-
----
-
-## Validation Rules
-
-### Mutually Exclusive Field Groups
-
-These field groups are mutually exclusive - specifying more than one causes a validation error:
-
-| Group | Fields | Error Message |
-|-------|--------|---------------|
-| Port | `port`, `automatic_port`, `lb_port` | Choose exactly one port configuration method |
-| TLS | `no_tls`, `use_tls` | Choose exactly one TLS configuration |
-| Health Check Port | `same_as_endpoint_port`, `health_check_port` | Choose exactly one health check port method |
-| Circuit Breaker | `default_circuit_breaker`, `disable_circuit_breaker`, `circuit_breaker` | Choose exactly one circuit breaker configuration |
-| Outlier Detection | `disable_outlier_detection`, `outlier_detection` | Choose exactly one outlier detection configuration |
-| Panic Threshold | `no_panic_threshold`, `panic_threshold` | Choose exactly one panic threshold configuration |
-| Subset LB | `disable_subsets`, `enable_subsets` | Choose exactly one subset load balancing configuration |
-| HTTP Protocol | `auto_http_config`, `http1_config`, `http2_options` | Choose exactly one HTTP protocol configuration |
-| Proxy Protocol | `disable_proxy_protocol`, `proxy_protocol_v1`, `proxy_protocol_v2` | Choose exactly one proxy protocol configuration |
-| LB Source IP | `disable_lb_source_ip_persistance`, `enable_lb_source_ip_persistance` | Choose exactly one LB source IP persistence configuration |
-
-### Field Constraints
-
-| Field | Type | Constraint |
-|-------|------|------------|
-| `spec.port` | integer | 1-65535 |
-| `spec.advanced_options.connection_timeout` | integer | 0-1,800,000 ms |
-| `spec.advanced_options.http_idle_timeout` | integer | 0-600,000 ms |
-| `spec.advanced_options.panic_threshold` | integer | 0-100 (percentage) |
-| `metadata.name` | string | 1-63 chars, `^[a-z0-9]([-a-z0-9]*[a-z0-9])?$` |
-
----
-
-## Integration Examples
-
-### Python CLI Tool
-
-```python
-from typing import Any
-
-class OriginPoolValidator:
-    """Validate origin pool configurations using discovered rules."""
-
-    REQUIRED_FIELDS = ["metadata.name", "metadata.namespace", "spec.origin_servers", "spec.port"]
-
-    SERVER_DEFAULTS = {
-        "no_tls": {},
-        "healthcheck": [],
-        "loadbalancer_algorithm": "ROUND_ROBIN",
-        "endpoint_selection": "DISTRIBUTED",
+```json
+{
+  "origin_servers": [
+    {
+      "public_name": {
+        "dns_name": "backend.example.com"
+      }
     }
-
-    LB_ALGORITHMS = ["ROUND_ROBIN", "LEAST_REQUEST", "RING_HASH", "RANDOM", "LB_OVERRIDE"]
-    ENDPOINT_SELECTIONS = ["DISTRIBUTED", "LOCAL_ONLY", "LOCAL_PREFERRED"]
-
-    def validate(self, config: dict[str, Any]) -> list[str]:
-        errors = []
-
-        # Check required fields
-        for field in self.REQUIRED_FIELDS:
-            if not self._get_nested(config, field):
-                errors.append(f"Missing required field: {field}")
-
-        # Validate enum values
-        lb_algo = self._get_nested(config, "spec.loadbalancer_algorithm")
-        if lb_algo and lb_algo not in self.LB_ALGORITHMS:
-            errors.append(f"Invalid loadbalancer_algorithm: {lb_algo}")
-
-        # Check mutually exclusive fields
-        port_fields = ["spec.port", "spec.automatic_port", "spec.lb_port"]
-        present = [f for f in port_fields if self._get_nested(config, f) is not None]
-        if len(present) > 1:
-            errors.append(f"Mutually exclusive fields: {', '.join(present)}")
-
-        return errors
-
-    def warn_ui_discrepancies(self, config: dict[str, Any]) -> list[str]:
-        warnings = []
-        if "loadbalancer_algorithm" not in config.get("spec", {}):
-            warnings.append(
-                "loadbalancer_algorithm not specified: "
-                "Server will apply 'ROUND_ROBIN' (UI shows 'LB_OVERRIDE' by default)"
-            )
-        return warnings
-```
-
-### Go Terraform Provider
-
-```go
-func resourceOriginPoolSchema() map[string]*schema.Schema {
-    return map[string]*schema.Schema{
-        "loadbalancer_algorithm": {
-            Type:        schema.TypeString,
-            Optional:    true,
-            Default:     "ROUND_ROBIN",  // Match server default, not UI default
-            Description: "Load balancing algorithm. Server default: ROUND_ROBIN (UI shows LB_OVERRIDE)",
-            ValidateFunc: validation.StringInSlice([]string{
-                "ROUND_ROBIN", "LEAST_REQUEST", "RING_HASH", "RANDOM", "LB_OVERRIDE",
-            }, false),
-        },
-        "endpoint_selection": {
-            Type:        schema.TypeString,
-            Optional:    true,
-            Default:     "DISTRIBUTED",
-            Description: "Endpoint selection policy",
-            ValidateFunc: validation.StringInSlice([]string{
-                "DISTRIBUTED", "LOCAL_ONLY", "LOCAL_PREFERRED",
-            }, false),
-        },
-        // ... other fields
-    }
+  ]
 }
 ```
 
-### AI Assistant MCP Tool
+### Example: public_ip
 
-```python
-def get_origin_pool_guidance() -> dict:
-    """Provide origin pool configuration guidance for AI assistants."""
-    return {
-        "minimum_config": {
-            "metadata": {"name": "example", "namespace": "default"},
-            "spec": {
-                "origin_servers": [{"public_name": {"dns_name": "backend.example.com"}}],
-                "port": 443
-            }
-        },
-        "important_notes": [
-            "spec.port is REQUIRED - no default is applied",
-            "spec.origin_servers requires at least 1 item",
-            "loadbalancer_algorithm defaults to ROUND_ROBIN (UI shows LB_OVERRIDE)",
-            "advanced_options is optional - all options have sensible defaults"
-        ],
-        "oneof_defaults": {
-            "port_choice": "port",
-            "tls_choice": "no_tls",
-            "circuit_breaker_choice": "default_circuit_breaker"
-        }
+```json
+{
+  "origin_servers": [
+    {
+      "public_ip": {
+        "ip": "8.8.8.8"
+      }
     }
+  ]
+}
 ```
 
----
+## TODO: Site-Dependent Origin Server Types
 
-## Fetching Validation Data
+The following origin server types require "site" resource logic development before implementation:
 
-The validation specification is published at:
+| Type | Description | Required Fields | Status |
+|------|-------------|-----------------|--------|
+| `private_ip` | Origin server with private/public IP and site info | `ip`, `site_locator`, `network_choice`, `snat_pool` | 🔲 Pending site logic |
+| `private_name` | Origin server with DNS name and site info | `dns_name`, `site_locator`, `network_choice`, `snat_pool` | 🔲 Pending site logic |
+| `k8s_service` | Kubernetes service with site info | `service_name`, `site_locator`, `network_choice` | 🔲 Pending site logic |
+| `consul_service` | HashiCorp Consul service with site info | `service_name`, `site_locator`, `network_choice` | 🔲 Pending site logic |
 
-```bash
-# Via GitHub Pages
-curl -O https://robinmordasiewicz.github.io/f5xc-api-enriched/specifications/api/validation.json
+### Implementation Requirements
 
-# Via raw GitHub
-curl -O https://raw.githubusercontent.com/robinmordasiewicz/f5xc-api-enriched/main/docs/specifications/api/validation.json
-```
+Before these types can be fully documented:
 
-Programmatic access (v2.1.0+ unified structure):
+1. **Site Resource Discovery** - Document `site` resource schema and site_locator patterns
+2. **Network Choice Enum** - Document `network_choice` constrained values (site_local_inside, site_local_outside, etc.)
+3. **SNAT Pool Options** - Document SNAT pool configuration patterns
+4. **Cross-Resource References** - Define how origin_pool references site resources
 
-```python
-import requests
+### Tracking
 
-def load_origin_pool_validation():
-    """Load origin pool validation data using v2.1.0 unified defaults structure."""
-    url = "https://robinmordasiewicz.github.io/f5xc-api-enriched/specifications/api/validation.json"
-    spec = requests.get(url).json()
-
-    # Access unified defaults structure (v2.1.0+)
-    origin_pool = spec["defaults"]["resources"]["origin_pool"]
-
-    return {
-        "required": spec["required_fields"]["resources"]["origin_pool"],
-        "server_applied": origin_pool.get("server_applied", {}),
-        "recommended": origin_pool.get("recommended", {}),
-        "advanced_options": origin_pool.get("advanced_options", {}),
-        "oneof_choices": origin_pool.get("oneof_choices", {}),
-        "ui_vs_server": origin_pool.get("ui_vs_server", {}),
-    }
-
-# Example output:
-# {
-#     "required": {"create": [...], "update": [...], "minimum_config": [...]},
-#     "server_applied": {"no_tls": {}, "loadbalancer_algorithm": "ROUND_ROBIN", ...},
-#     "recommended": {"port": 443, "connection_timeout": 2000, "http_idle_timeout": 300000},
-#     "advanced_options": {"connection_timeout": 2000, "same_as_endpoint_port": {}, ...},
-#     "oneof_choices": {"tls_choice": "no_tls", "circuit_breaker_choice": "default_circuit_breaker", ...},
-#     "ui_vs_server": {"loadbalancer_algorithm": {"ui_default": "LB_OVERRIDE", "server_default": "ROUND_ROBIN"}}
-# }
-```
-
-**Access Patterns:**
-
-```python
-spec = load_validation_spec()
-
-# Get all origin_pool defaults
-op_defaults = spec["defaults"]["resources"]["origin_pool"]
-
-# Get server-applied defaults
-server_applied = op_defaults["server_applied"]
-# {"no_tls": {}, "healthcheck": [], "loadbalancer_algorithm": "ROUND_ROBIN", ...}
-
-# Get recommended values
-recommended = op_defaults["recommended"]
-# {"port": 443, "connection_timeout": 2000, "http_idle_timeout": 300000}
-
-# Get OneOf default selections
-oneof = op_defaults["oneof_choices"]
-# {"tls_choice": "no_tls", "circuit_breaker_choice": "default_circuit_breaker", ...}
-
-# Get UI vs Server discrepancies
-ui_vs_server = op_defaults["ui_vs_server"]
-# {"loadbalancer_algorithm": {"ui_default": "LB_OVERRIDE", "server_default": "ROUND_ROBIN"}}
-```
-
-> **Migration Note**: v2.1.0 consolidated `server_defaults`, `oneof_defaults`, `ui_vs_server_defaults`, and `advanced_options_defaults` into `defaults.resources.<resource>`. See [VALIDATION_SPEC.md](VALIDATION_SPEC.md) for full details.
-
----
-
-## Discovery Methodology
-
-These discoveries were made through systematic API testing:
-
-1. **Baseline Test**: Create origin pool with minimal config (only required fields)
-2. **Read Back**: Retrieve the created resource to see server-applied values
-3. **Variation Tests**: Test each UI option with different values
-4. **Comparison**: Compare sent vs received payloads to identify defaults
-
-The case study script is available at:
-`scripts/case_study_origin_pool_advanced.py`
-
-Run discovery (requires API access):
-
-```bash
-export F5XC_API_URL="https://tenant.console.ves.volterra.io"
-export F5XC_API_TOKEN="your-token"
-python -m scripts.case_study_origin_pool_advanced --verbose
-```
-
----
+- Configuration placeholder: `config/discovered_defaults.yaml` → `origin_pool.origin_server_types.enums`
+- Related sprint: Site resource schema enrichments
 
 ## Related Documentation
 
-- [VALIDATION_SPEC.md](VALIDATION_SPEC.md) - Full validation specification format (unified defaults v2.1.0+)
-- [HEALTHCHECK_ENHANCEMENTS.md](HEALTHCHECK_ENHANCEMENTS.md) - Healthcheck defaults and enhancements
-- [config/discovered_defaults.yaml](../config/discovered_defaults.yaml) - Raw discovery data
-- [config/validation_schema.yaml](../config/validation_schema.yaml) - Validation schema source
+- [Development Guide - OpenAPI Extensions](DEVELOPMENT.md#openapi-extensions) - Extension definitions and usage
+- [Validation Specification](VALIDATION_SPEC.md) - validation.json format and structure
+- [Healthcheck Enhancements](HEALTHCHECK_ENHANCEMENTS.md) - Healthcheck schema enrichments
 
 ## Changelog
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 2.1.2 | 2026-01-18 | Added origin server types section with public_name/public_ip; TODO markers for site-dependent types |
+| 2.1.1 | 2026-01-18 | Rewritten as pure API reference; removed downstream code examples |
 | 2.1.0 | 2026-01-18 | Updated to unified defaults structure in validation.json |
 | 2.0.33 | 2026-01-17 | Initial origin pool enhancements documentation |
-
----
-
-*Last Updated: 2026-01-18*
-*Version: 2.1.0*


### PR DESCRIPTION
## Summary

- Add `origin_server_types` section with 6 type definitions for origin pool configuration
  - `public_name` and `public_ip` fully specified (completed)
  - `private_ip`, `private_name`, `k8s_service`, `consul_service` marked as TODO (requires site logic development)
- Restructure nested `advanced_options` with `defaults/recommended` sub-keys for consistency
- Rename `oneof_defaults` to `oneof_recommended` to align with healthcheck pattern
- Update documentation (ORIGINPOOL_ENHANCEMENTS.md, DEVELOPMENT.md, HEALTHCHECK_ENHANCEMENTS.md)

## Test plan

- [x] Run `make pipeline` - verified enrichment passes
- [x] Check validation.json export includes origin_pool config
- [ ] Verify CI pipeline passes all checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)