### PR TITLE
fix: resolve workflow YAML parsing and linting issues

### DIFF
--- a/.github/workflows/sync-and-enrich.yml
+++ b/.github/workflows/sync-and-enrich.yml
@@ -353,76 +353,74 @@ jobs:
             EXISTING_ENTRIES=$(awk '/^## Version/{if(++c==2)found=1}found' CHANGELOG.md || echo "")
           fi
 
-          # Build new changelog entry
-          NEW_ENTRY=$(cat << EOF
-## Version $FULL_VERSION ($DATE)
+          # Calculate statistics
+          ORIG_SPECS=$(find specs/original -name '*.json' 2>/dev/null | wc -l | xargs)
+          DOMAIN_COUNT=$(jq '.specifications | length' docs/specifications/api/index.json)
+          PATH_COUNT=$(jq '[.specifications[].path_count] | add' docs/specifications/api/index.json)
+          SCHEMA_COUNT=$(jq '[.specifications[].schema_count] | add' docs/specifications/api/index.json)
 
-### Version Information
-| Field | Value |
-|-------|-------|
-| Full Version | $FULL_VERSION |
-| Upstream Timestamp | $UPSTREAM_TS |
-| Upstream ETag | $UPSTREAM_ETAG |
-| Enriched Version | $ENRICHED_VER |
-
-### Release Type
-- **$BUMP_TYPE** release
-
-### Changes
-- Updated API specifications from F5 Distributed Cloud
-- Applied enrichment pipeline:
-  - Acronym normalization (100+ terms)
-  - Grammar improvements
-  - Branding updates (Volterra → F5 Distributed Cloud)
-- Applied normalization pipeline:
-  - Fixed orphan \$ref references
-  - Removed empty operations
-  - Type standardization
-- Validated with Spectral OpenAPI linter
-- Merged specifications by domain
-
-### Statistics
-- Original specs: $(find specs/original -name '*.json' 2>/dev/null | wc -l | xargs)
-- Domains: $(jq '.specifications | length' docs/specifications/api/index.json)
-- Total paths: $(jq '[.specifications[].path_count] | add' docs/specifications/api/index.json)
-- Total schemas: $(jq '[.specifications[].schema_count] | add' docs/specifications/api/index.json)
-EOF
-)
-
-          # Add discovery section if available
-          if [ "$HAS_DISCOVERY" = "true" ] && [ -n "$DISCOVERY_ENDPOINTS" ]; then
-            NEW_ENTRY="${NEW_ENTRY}
-
-### API Discovery Enrichment
-- Discovery timestamp: $DISCOVERY_TIMESTAMP
-- Endpoints explored: $DISCOVERY_SUCCESS / $DISCOVERY_ENDPOINTS
-- Applied x-discovered-* extensions from live API exploration
-- See \`reports/constraint-analysis.md\` for detailed comparison"
-          fi
-
-          NEW_ENTRY="${NEW_ENTRY}
-
-### Output Structure
-\`\`\`text
-docs/specifications/api/
-├── [domain].json        # Domain-specific specs
-├── openapi.json         # Master combined spec
-└── index.json           # Metadata index
-\`\`\`
-
-### Download
-- ZIP Package: F5xc-api-(${UPSTREAM_TS}-${ENRICHED_VER}).zip
-
-### Source
-- Source: F5 Distributed Cloud OpenAPI specifications
-- Upstream: $UPSTREAM_TS (ETag: $UPSTREAM_ETAG)
-"
-
-          # Write new changelog with prepended entry
+          # Write changelog directly to avoid heredoc YAML parsing issues
           {
             echo "# Changelog"
             echo ""
-            echo "$NEW_ENTRY"
+            echo "## Version $FULL_VERSION ($DATE)"
+            echo ""
+            echo "### Version Information"
+            echo "- **Full Version**: $FULL_VERSION"
+            echo "- **Upstream Timestamp**: $UPSTREAM_TS"
+            echo "- **Upstream ETag**: $UPSTREAM_ETAG"
+            echo "- **Enriched Version**: $ENRICHED_VER"
+            echo ""
+            echo "### Release Type"
+            echo "- **$BUMP_TYPE** release"
+            echo ""
+            echo "### Changes"
+            echo "- Updated API specifications from F5 Distributed Cloud"
+            echo "- Applied enrichment pipeline:"
+            echo "  - Acronym normalization (100+ terms)"
+            echo "  - Grammar improvements"
+            echo "  - Branding updates (Volterra → F5 Distributed Cloud)"
+            echo "- Applied normalization pipeline:"
+            echo "  - Fixed orphan \$ref references"
+            echo "  - Removed empty operations"
+            echo "  - Type standardization"
+            echo "- Validated with Spectral OpenAPI linter"
+            echo "- Merged specifications by domain"
+            echo ""
+            echo "### Statistics"
+            echo "- Original specs: $ORIG_SPECS"
+            echo "- Domains: $DOMAIN_COUNT"
+            echo "- Total paths: $PATH_COUNT"
+            echo "- Total schemas: $SCHEMA_COUNT"
+
+            # Add discovery section if available
+            if [ "$HAS_DISCOVERY" = "true" ] && [ -n "$DISCOVERY_ENDPOINTS" ]; then
+              echo ""
+              echo "### API Discovery Enrichment"
+              echo "- Discovery timestamp: $DISCOVERY_TIMESTAMP"
+              echo "- Endpoints explored: $DISCOVERY_SUCCESS / $DISCOVERY_ENDPOINTS"
+              echo "- Applied x-discovered-* extensions from live API exploration"
+              echo "- See \\\`reports/constraint-analysis.md\\\` for detailed comparison"
+            fi
+
+            echo ""
+            echo "### Output Structure"
+            echo "\\\`\\\`\\\`text"
+            echo "docs/specifications/api/"
+            echo "├── [domain].json        # Domain-specific specs"
+            echo "├── openapi.json         # Master combined spec"
+            echo "└── index.json           # Metadata index"
+            echo "\\\`\\\`\\\`"
+            echo ""
+            echo "### Download"
+            echo "- ZIP Package: F5xc-api-(${UPSTREAM_TS}-${ENRICHED_VER}).zip"
+            echo ""
+            echo "### Source"
+            echo "- Source: F5 Distributed Cloud OpenAPI specifications"
+            echo "- Upstream: $UPSTREAM_TS (ETag: $UPSTREAM_ETAG)"
+            echo ""
+
+            # Append existing entries
             if [ -n "$EXISTING_ENTRIES" ]; then
               echo "$EXISTING_ENTRIES"
             fi

--- a/config/discovered_defaults.yaml
+++ b/config/discovered_defaults.yaml
@@ -317,13 +317,6 @@ resources:
           recommended:
             ip: ""  # Required, user must provide (e.g., "8.8.8.8")
 
-      # TODO: Site-dependent nested configurations
-      # These require completion after "site" development sprint:
-      # - private_ip: ip, site_locator, network_choice, snat_pool
-      # - private_name: dns_name, site_locator, network_choice, snat_pool
-      # - k8s_service: service_name, site_locator, network_choice
-      # - consul_service: service_name, site_locator, network_choice
-
 # Documentation for adding new defaults:
 # 1. Create resource in F5 XC with minimal/empty spec via API
 # 2. Read back the created resource to see server-applied values
@@ -333,3 +326,10 @@ resources:
 # Note: For origin_pool, additional nested defaults exist:
 # - origin_servers[].labels: {} (empty labels)
 # - origin_servers[].public_name.refresh_interval: 0 (use system default)
+#
+# TODO: Site-dependent nested configurations for origin_pool
+# These require completion after "site" development sprint:
+# - private_ip: ip, site_locator, network_choice, snat_pool
+# - private_name: dns_name, site_locator, network_choice, snat_pool
+# - k8s_service: service_name, site_locator, network_choice
+# - consul_service: service_name, site_locator, network_choice

--- a/config/schemas/enrichment.schema.json
+++ b/config/schemas/enrichment.schema.json
@@ -7,7 +7,7 @@
   "properties": {
     "source": {
       "type": "object",
-      "required": ["url", "etag_file", "version_file"],
+      "required": ["url", "etag_file"],
       "properties": {
         "url": {
           "type": "string",
@@ -20,7 +20,7 @@
         },
         "version_file": {
           "type": "string",
-          "description": "Path to version tracking file"
+          "description": "Path to version tracking file (deprecated - version now derived from git tags)"
         }
       }
     },

--- a/scripts/download.py
+++ b/scripts/download.py
@@ -17,6 +17,8 @@ import yaml
 from rich.console import Console
 from rich.progress import Progress, SpinnerColumn, TextColumn
 
+from scripts.utils.version_calculator import get_version_from_tags
+
 console = Console()
 
 # Default configuration
@@ -79,20 +81,14 @@ def save_etag(etag: str, etag_file: Path) -> None:
     etag_file.write_text(etag)
 
 
-def get_version(version_file: Path | None = None) -> str:
+def get_version() -> str:
     """Get version from git tags.
 
     Uses tag-based versioning to eliminate race conditions from file-based versioning.
-    The version_file parameter is kept for backward compatibility but is ignored.
-
-    Args:
-        version_file: Deprecated. Kept for backward compatibility.
 
     Returns:
         Version string in semver format (e.g., "2.0.38").
     """
-    from scripts.utils.version_calculator import get_version_from_tags
-
     return get_version_from_tags()
 
 

--- a/scripts/merge_specs.py
+++ b/scripts/merge_specs.py
@@ -50,6 +50,7 @@ from scripts.utils.extension_constants import (
     X_F5XC_USE_CASES,
 )
 from scripts.utils.server_variables import ServerVariableHelper
+from scripts.utils.version_calculator import get_version_from_tags
 
 console = Console()
 
@@ -578,8 +579,6 @@ def get_enriched_version() -> str:
 
     Uses tag-based versioning to eliminate race conditions from file-based versioning.
     """
-    from scripts.utils.version_calculator import get_version_from_tags
-
     version = get_version_from_tags()
     if version == "0.0.0":
         # Fallback to date-based version if no tags exist

--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -94,6 +94,7 @@ from scripts.utils import (
     ValidationEnricher,
     ValidationExporter,
     categorize_spec,
+    get_version_from_tags,
 )
 from scripts.utils.batch_processor import BatchSpecProcessor
 from scripts.utils.domain_metadata import (
@@ -1405,8 +1406,6 @@ def get_version() -> str:
 
     Uses tag-based versioning to eliminate race conditions from file-based versioning.
     """
-    from scripts.utils.version_calculator import get_version_from_tags
-
     version = get_version_from_tags()
     if version == "0.0.0":
         # Fallback to date-based version if no tags exist

--- a/scripts/utils/version_calculator.py
+++ b/scripts/utils/version_calculator.py
@@ -56,7 +56,7 @@ def calculate_next_version(current: str, bump_type: str) -> str:
         return f"{major + 1}.0.0"
     if bump_type == "minor":
         return f"{major}.{minor + 1}.0"
-    # patch (default)
+    # Default: patch bump
     return f"{major}.{minor}.{patch + 1}"
 
 


### PR DESCRIPTION
## Summary

Post-merge fixes for the dynamic versioning implementation (PR #489). The workflow file had YAML parsing issues that caused GitHub Actions failures.

### Changes

- **Workflow YAML fix**: Replaced heredoc with echo statements to avoid YAML parsing issues (the heredoc with markdown tables had pipe characters that caused parsing conflicts)
- **Schema validation fix**: Made `version_file` optional in `enrichment.schema.json` since versioning is now tag-based
- **Python import fixes**: Moved imports to top-level for PLC0415 compliance in:
  - `scripts/download.py`
  - `scripts/merge_specs.py`
  - `scripts/pipeline.py`
- **Yamllint fix**: Fixed comment indentation in `config/discovered_defaults.yaml`
- **Ruff fix**: Rewording comment in `version_calculator.py` to avoid ERA001 (commented-out code detection)

## Test plan

- [x] Local pre-commit passes (all hooks except `no-commit-to-branch` which is expected on feature branches)
- [ ] GitHub Actions workflow should now parse correctly
- [ ] PR Check workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)