### PR TITLE
fix: fetch tags for version calculation and force-add ignored files

### DIFF
--- a/.github/workflows/sync-and-enrich.yml
+++ b/.github/workflows/sync-and-enrich.yml
@@ -93,7 +93,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          fetch-depth: 2  # Need previous commit for diff
+          fetch-depth: 0  # Full history needed for git describe --tags
+          fetch-tags: true  # Explicitly fetch tags for version calculation
 
       - name: Setup Python
         uses: actions/setup-python@v6.1.0
@@ -447,7 +448,8 @@ jobs:
           git config --local user.name "github-actions[bot]"
 
           # Stage enriched outputs (NOT .version - it no longer exists)
-          git add CHANGELOG.md .etag docs/specifications/api/
+          # Use -f to add docs/specifications/api/ which is in .gitignore
+          git add -f CHANGELOG.md .etag docs/specifications/api/
 
           if ! git diff --staged --quiet; then
             # Create release commit with [skip ci] to prevent recursive workflow triggers


### PR DESCRIPTION
## Summary

Fixes GitHub Actions workflow failures from run #21129082694:

1. **Version calculation returning 0.0.0**: The checkout step was using `fetch-depth: 2` which doesn't fetch tags. Changed to `fetch-depth: 0` and added `fetch-tags: true` so that `git describe --tags` can find existing version tags.

2. **Git add failing for ignored files**: `docs/specifications/api/` is in `.gitignore`, causing `git add` to fail. Added `-f` flag to force-add these files.

## Test plan

- [ ] Workflow should now correctly identify version from tags (e.g., v2.0.39)
- [ ] Git add should succeed for the gitignored docs directory
- [ ] Full sync-and-enrich workflow completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)