### PR TITLE
fix: configure git to use VERSION_BUMP_PAT for branch protection bypass

### DIFF
--- a/.github/workflows/sync-and-enrich.yml
+++ b/.github/workflows/sync-and-enrich.yml
@@ -447,6 +447,9 @@ jobs:
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
 
+          # Configure git to use VERSION_BUMP_PAT for authentication to bypass branch protection
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+
           # Stage enriched outputs (NOT .version - it no longer exists)
           # Use -f to add docs/specifications/api/ which is in .gitignore
           git add -f CHANGELOG.md .etag docs/specifications/api/


### PR DESCRIPTION
## Summary
- Configure git remote URL with VERSION_BUMP_PAT token to bypass branch protection for release commits
- Enables direct pushes to main from the workflow without PR requirement

## Problem
The "Commit and tag release" step was failing with:
```
error: GH013: Repository rule violations found for refs/heads/main.
- Changes must be made through a pull request.
- Required status check "Validate PR" is expected.
```

The `VERSION_BUMP_PAT` secret was configured as `GH_TOKEN` but git wasn't using it for authentication.

## Solution
Add `git remote set-url origin` with the PAT token embedded in the URL, allowing git push operations to authenticate with elevated permissions that can bypass branch protection.

## Test plan
- [ ] PR checks pass
- [ ] After merge, sync-and-enrich workflow completes successfully
- [ ] Release commit and tag are pushed to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)