### PR TITLE
feat: add x-f5xc-conflicts-with extension for OneOf field validation

### DIFF
--- a/config/extension_registry.yaml
+++ b/config/extension_registry.yaml
@@ -277,6 +277,17 @@ property_level:
     added_in: "3.1.0"
     issue: "#449"
 
+  x-f5xc-conflicts-with:
+    type: array
+    items: string
+    purpose: Declares mutual exclusivity with other OneOf group properties
+    consumers: [terraform, cli, mcp, ide]
+    source: "Auto-derived from x-ves-oneof-field-* extensions"
+    example: ["use_origin_server_name"]
+    added_in: "3.2.0"
+    issue: "#494"
+    note: "Enables downstream tools to validate conflicts at schema level rather than runtime"
+
 # =============================================================================
 # OPERATION-LEVEL EXTENSIONS (path operations)
 # =============================================================================

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -312,6 +312,7 @@ The enrichment pipeline uses vendor extensions to embed validation and default v
 | `x-f5xc-server-default` | The F5 XC API server applies this value when the field is omitted | Field is optional; omitting it produces the documented default behavior |
 | `x-f5xc-recommended-value` | The F5 XC web console pre-populates this value for new resources | Field has no server default but this value represents typical configuration |
 | `x-f5xc-recommended-oneof-variant` | The F5 XC console pre-selects this OneOf variant | Identifies the typical choice when multiple mutually exclusive options exist |
+| `x-f5xc-conflicts-with` | Lists other properties that cannot be used together with this field | Property is part of a OneOf group; only one of the conflicting properties can be specified |
 
 **Key distinction**: Server-applied defaults are handled by the API automatically. Recommended values are suggestions that require explicit inclusion if desired.
 
@@ -327,13 +328,14 @@ The enrichment pipeline uses vendor extensions to embed validation and default v
 - `update`: Required when updating the resource
 - `minimum_config`: Required for minimum viable configuration
 
-### Default Value Extensions
+### Default Value and OneOf Extensions
 
 | Extension | Purpose |
 |-----------|---------|
 | `x-f5xc-server-default: true` | Marks server-applied defaults |
 | `x-f5xc-recommended-value` | F5 XC console pre-populated value |
 | `x-f5xc-recommended-oneof-variant` | Recommended OneOf variant |
+| `x-f5xc-conflicts-with` | Mutual exclusivity with other OneOf properties |
 
 #### x-f5xc-server-default
 
@@ -372,6 +374,32 @@ healthcheckCreateSpecType:
   x-f5xc-recommended-oneof-variant:
     health_check: "http_health_check"
 ```
+
+#### x-f5xc-conflicts-with
+
+**Type**: `array` of strings
+
+**Added**: v3.2.0 (Issue #494)
+
+Declares mutual exclusivity relationships between OneOf group members. Auto-derived from `x-ves-oneof-field-*` extensions. This enables downstream tools (Terraform, CLI, MCP) to validate conflicts at schema level rather than runtime.
+
+```yaml
+host_header:
+  type: string
+  x-f5xc-conflicts-with: ["use_origin_server_name"]
+
+use_origin_server_name:
+  type: object
+  x-f5xc-conflicts-with: ["host_header"]
+```
+
+**Use cases**:
+- Terraform providers can generate validation rules
+- CLI tools can warn about conflicting field combinations
+- AI assistants can generate correct OneOf configurations
+- IDE extensions can provide conflict-aware autocompletion
+
+**Source**: Auto-derived from F5 native `x-ves-oneof-field-*` extensions during pipeline enrichment.
 
 ### Validation Rule Implications
 

--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -72,6 +72,7 @@ from scripts.utils import (
     AcronymNormalizer,
     BestPracticesEnricher,
     BrandingTransformer,
+    ConflictsWithEnricher,
     ConsistencyValidator,
     ConstraintReconciler,
     DefaultValueEnricher,
@@ -182,6 +183,7 @@ class PipelineStats:
     best_practices_enriched: int = 0
     guided_workflows_added: int = 0
     error_resolutions_added: int = 0
+    conflicts_with_added: int = 0
     errors: list[dict[str, Any]] = field(default_factory=list)
 
 
@@ -1084,6 +1086,7 @@ def merge_specs_by_domain(
         "best_practices_enriched": 0,
         "guided_workflows_added": 0,
         "server_defaults_added": 0,
+        "conflicts_with_added": 0,
     }
 
     # Load description enricher for domain-specific descriptions
@@ -1097,6 +1100,10 @@ def merge_specs_by_domain(
     # Load enrichers that require merged schemas (Issue #449)
     # Server-applied defaults need the full merged schema to match patterns
     default_value_enricher = DefaultValueEnricher()
+
+    # Load conflicts-with enricher (Issue #494)
+    # Auto-derives mutual exclusivity from x-ves-oneof-field-* extensions
+    conflicts_with_enricher = ConflictsWithEnricher()
 
     for domain, spec_list in sorted(domain_specs.items()):
         domain_title = domain.replace("_", " ").title()
@@ -1240,6 +1247,13 @@ def merge_specs_by_domain(
             stats["server_defaults_added"],
             dv_stats.get("defaults_added", 0),
         )
+
+        # Conflicts-with: auto-derive mutual exclusivity from x-ves-oneof-field-* (Issue #494)
+        merged_spec = conflicts_with_enricher.enrich_spec(merged_spec)
+        cw_stats = conflicts_with_enricher.get_stats()
+        stats["conflicts_with_added"] += cw_stats.get("conflicts_added", 0)
+        # Reset stats for next domain to avoid double-counting
+        conflicts_with_enricher.reset_stats()
 
         merged[domain] = merged_spec
         stats["domains"] += 1
@@ -1619,6 +1633,7 @@ def run_pipeline(
             stats.schemas_merged = merge_stats["schemas"]
             stats.best_practices_enriched = merge_stats.get("best_practices_enriched", 0)
             stats.guided_workflows_added = merge_stats.get("guided_workflows_added", 0)
+            stats.conflicts_with_added = merge_stats.get("conflicts_with_added", 0)
 
             # Clear processed_specs to free memory before saving
             del processed_specs
@@ -1703,6 +1718,8 @@ def print_summary(stats: PipelineStats) -> None:
         table.add_row("Guided Workflows Added", str(stats.guided_workflows_added))
     if stats.error_resolutions_added > 0:
         table.add_row("Error Resolutions Added", str(stats.error_resolutions_added))
+    if stats.conflicts_with_added > 0:
+        table.add_row("Conflicts-With Added", str(stats.conflicts_with_added))
 
     console.print(table)
 
@@ -1738,6 +1755,7 @@ def generate_report(stats: PipelineStats, output_path: Path) -> None:
             "best_practices_enriched": stats.best_practices_enriched,
             "guided_workflows_added": stats.guided_workflows_added,
             "error_resolutions_added": stats.error_resolutions_added,
+            "conflicts_with_added": stats.conflicts_with_added,
         },
         "errors": stats.errors,
     }

--- a/scripts/utils/__init__.py
+++ b/scripts/utils/__init__.py
@@ -6,6 +6,7 @@ from .acronym_enricher import AcronymEnricher
 from .acronyms import AcronymNormalizer
 from .best_practices_enricher import BestPracticesEnricher
 from .branding import BrandingNormalizer, BrandingStats, BrandingTransformer, BrandingValidator
+from .conflicts_with_enricher import ConflictsWithEnricher
 from .consistency_validator import ConsistencyValidator
 from .constraint_analyzer import ConstraintAnalyzer
 from .constraint_reconciler import ConstraintReconciler
@@ -49,6 +50,7 @@ __all__ = [
     "BrandingStats",
     "BrandingTransformer",
     "BrandingValidator",
+    "ConflictsWithEnricher",
     "ConsistencyValidator",
     "ConstraintAnalyzer",
     "ConstraintReconciler",

--- a/scripts/utils/conflicts_with_enricher.py
+++ b/scripts/utils/conflicts_with_enricher.py
@@ -1,0 +1,275 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+"""Conflicts-with enricher for OpenAPI specifications.
+
+This enricher auto-derives mutual exclusivity relationships from existing
+x-ves-oneof-field-* extensions and adds x-f5xc-conflicts-with to each
+property, enabling downstream tools (Terraform, CLI, MCP) to validate
+conflicts at schema level rather than runtime.
+
+Issue: #494 - Add x-f5xc-conflicts-with extension for OneOf groups
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+from .extension_constants import X_F5XC_CONFLICTS_WITH, X_VES_ONEOF_FIELD_PREFIX
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ConflictsWithEnrichmentStats:
+    """Statistics for conflicts-with enrichment."""
+
+    schemas_processed: int = 0
+    schemas_with_oneof: int = 0
+    oneof_groups_found: int = 0
+    conflicts_added: int = 0
+    properties_enriched: int = 0
+    existing_preserved: int = 0
+    errors: list[dict[str, Any]] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert stats to dictionary."""
+        return {
+            "schemas_processed": self.schemas_processed,
+            "schemas_with_oneof": self.schemas_with_oneof,
+            "oneof_groups_found": self.oneof_groups_found,
+            "conflicts_added": self.conflicts_added,
+            "properties_enriched": self.properties_enriched,
+            "existing_preserved": self.existing_preserved,
+            "error_count": len(self.errors),
+            "errors": self.errors,
+        }
+
+
+class ConflictsWithEnricher:
+    """Enrich OpenAPI specs with x-f5xc-conflicts-with extensions.
+
+    Auto-derives mutual exclusivity relationships from x-ves-oneof-field-*
+    extensions in schemas. For each OneOf group, adds x-f5xc-conflicts-with
+    to each variant property listing all other variants in the same group.
+
+    Example input schema:
+        {
+            "type": "object",
+            "x-ves-oneof-field-host_header_choice": ["host_header", "use_origin_server_name"],
+            "properties": {
+                "host_header": {"type": "string"},
+                "use_origin_server_name": {"type": "object"}
+            }
+        }
+
+    Example output:
+        {
+            "type": "object",
+            "x-ves-oneof-field-host_header_choice": ["host_header", "use_origin_server_name"],
+            "properties": {
+                "host_header": {
+                    "type": "string",
+                    "x-f5xc-conflicts-with": ["use_origin_server_name"]
+                },
+                "use_origin_server_name": {
+                    "type": "object",
+                    "x-f5xc-conflicts-with": ["host_header"]
+                }
+            }
+        }
+    """
+
+    def __init__(self) -> None:
+        """Initialize the enricher."""
+        self.stats = ConflictsWithEnrichmentStats()
+
+    def enrich_spec(self, spec: dict[str, Any]) -> dict[str, Any]:
+        """Enrich OpenAPI specification with conflicts-with extensions.
+
+        Args:
+            spec: OpenAPI specification dictionary
+
+        Returns:
+            Enriched specification
+        """
+        schemas = spec.get("components", {}).get("schemas", {})
+
+        if not schemas:
+            logger.debug("No schemas found in spec, skipping conflicts-with enrichment")
+            return spec
+
+        logger.info("Enriching %d schemas with conflicts-with extensions", len(schemas))
+
+        for schema_name, schema in schemas.items():
+            self.stats.schemas_processed += 1
+            self._enrich_schema(schema_name, schema)
+
+        logger.info("Conflicts-with enrichment complete: %s", self.stats.to_dict())
+        return spec
+
+    def _enrich_schema(self, schema_name: str, schema: dict[str, Any]) -> None:
+        """Enrich individual schema with conflicts-with extensions.
+
+        Args:
+            schema_name: Name of the schema
+            schema: Schema definition
+        """
+        if not isinstance(schema, dict):
+            return
+
+        # Find all x-ves-oneof-field-* extensions in the schema
+        oneof_groups = self._extract_oneof_groups(schema)
+
+        if not oneof_groups:
+            return
+
+        self.stats.schemas_with_oneof += 1
+        self.stats.oneof_groups_found += len(oneof_groups)
+
+        properties = schema.get("properties", {})
+        if not properties:
+            logger.debug(
+                "Schema %s has OneOf groups but no properties, skipping",
+                schema_name,
+            )
+            return
+
+        try:
+            # For each OneOf group, add conflicts-with to each variant property
+            for group_name, variants in oneof_groups.items():
+                self._apply_conflicts_to_group(
+                    schema_name,
+                    properties,
+                    group_name,
+                    variants,
+                )
+        except Exception as e:
+            logger.exception("Error enriching schema %s with conflicts-with", schema_name)
+            self.stats.errors.append(
+                {
+                    "schema": schema_name,
+                    "error": str(e),
+                },
+            )
+
+    def _extract_oneof_groups(
+        self,
+        schema: dict[str, Any],
+    ) -> dict[str, list[str]]:
+        """Extract OneOf groups from schema.
+
+        Finds all x-ves-oneof-field-* extensions and returns a mapping
+        of group names to variant field names.
+
+        Handles both list values and JSON-encoded string values (e.g.,
+        '["host_header","use_origin_server_name"]').
+
+        Args:
+            schema: Schema definition
+
+        Returns:
+            Dictionary mapping group names to lists of variant field names
+        """
+        oneof_groups: dict[str, list[str]] = {}
+
+        for key, value in schema.items():
+            if key.startswith(X_VES_ONEOF_FIELD_PREFIX):
+                # Extract group name from extension key
+                # e.g., "x-ves-oneof-field-host_header_choice" -> "host_header_choice"
+                group_name = key[len(X_VES_ONEOF_FIELD_PREFIX) :]
+
+                # Handle JSON-encoded string values
+                variants = value
+                if isinstance(value, str):
+                    try:
+                        variants = json.loads(value)
+                    except json.JSONDecodeError:
+                        logger.debug(
+                            "Could not parse OneOf group %s value as JSON: %s",
+                            group_name,
+                            value,
+                        )
+                        continue
+
+                if isinstance(variants, list) and len(variants) >= 2:
+                    # Only process groups with 2+ variants (single variant is not a conflict)
+                    oneof_groups[group_name] = variants
+                elif isinstance(variants, list) and len(variants) == 1:
+                    logger.debug(
+                        "Skipping single-variant OneOf group %s: %s",
+                        group_name,
+                        variants,
+                    )
+
+        return oneof_groups
+
+    def _apply_conflicts_to_group(
+        self,
+        schema_name: str,
+        properties: dict[str, Any],
+        group_name: str,
+        variants: list[str],
+    ) -> None:
+        """Apply conflicts-with extensions to properties in a OneOf group.
+
+        For each variant in the group, adds x-f5xc-conflicts-with listing
+        all other variants in the same group.
+
+        Args:
+            schema_name: Name of the schema (for logging)
+            properties: Properties dictionary from schema
+            group_name: Name of the OneOf group
+            variants: List of variant field names
+        """
+        for variant in variants:
+            if variant not in properties:
+                logger.debug(
+                    "Schema %s: variant %s not found in properties for group %s",
+                    schema_name,
+                    variant,
+                    group_name,
+                )
+                continue
+
+            prop_schema = properties[variant]
+            if not isinstance(prop_schema, dict):
+                continue
+
+            # Calculate other variants (all variants except this one)
+            other_variants = [v for v in variants if v != variant]
+
+            if not other_variants:
+                continue
+
+            # Check if x-f5xc-conflicts-with already exists
+            if X_F5XC_CONFLICTS_WITH in prop_schema:
+                # Preserve existing value, merge if needed
+                existing = prop_schema[X_F5XC_CONFLICTS_WITH]
+                if isinstance(existing, list):
+                    # Merge with existing, avoiding duplicates
+                    merged = list(set(existing) | set(other_variants))
+                    if merged != existing:
+                        prop_schema[X_F5XC_CONFLICTS_WITH] = sorted(merged)
+                        self.stats.conflicts_added += len(merged) - len(existing)
+                    self.stats.existing_preserved += 1
+                    continue
+
+            # Add new x-f5xc-conflicts-with extension
+            prop_schema[X_F5XC_CONFLICTS_WITH] = sorted(other_variants)
+            self.stats.properties_enriched += 1
+            self.stats.conflicts_added += len(other_variants)
+
+    def get_stats(self) -> dict[str, Any]:
+        """Get enrichment statistics.
+
+        Returns:
+            Statistics dictionary
+        """
+        return self.stats.to_dict()
+
+    def reset_stats(self) -> None:
+        """Reset statistics for a new enrichment run."""
+        self.stats = ConflictsWithEnrichmentStats()

--- a/scripts/utils/extension_constants.py
+++ b/scripts/utils/extension_constants.py
@@ -67,6 +67,7 @@ X_F5XC_DEPRECATED = "x-f5xc-deprecated"
 X_F5XC_SERVER_DEFAULT = "x-f5xc-server-default"
 X_F5XC_RECOMMENDED_VALUE = "x-f5xc-recommended-value"
 X_F5XC_RECOMMENDED_ONEOF_VARIANT = "x-f5xc-recommended-oneof-variant"
+X_F5XC_CONFLICTS_WITH = "x-f5xc-conflicts-with"
 
 # =============================================================================
 # OPERATION-LEVEL EXTENSIONS (path operations)
@@ -124,6 +125,11 @@ PRESERVED_NATIVE_EXTENSIONS = frozenset(
     ],
 )
 
+# Pattern prefix for F5 native OneOf field extensions (used for conflict derivation)
+# Extensions like x-ves-oneof-field-{group_name} define mutually exclusive fields
+# These are preserved (not in frozenset since it's a prefix pattern match)
+X_VES_ONEOF_FIELD_PREFIX = "x-ves-oneof-field-"
+
 # =============================================================================
 # VALID EXTENSIONS SET
 # =============================================================================
@@ -165,6 +171,7 @@ VALID_X_F5XC_EXTENSIONS = frozenset(
         X_F5XC_SERVER_DEFAULT,
         X_F5XC_RECOMMENDED_VALUE,
         X_F5XC_RECOMMENDED_ONEOF_VARIANT,
+        X_F5XC_CONFLICTS_WITH,
         # Operation-level
         X_F5XC_REQUIRED_FIELDS,
         X_F5XC_DANGER_LEVEL,

--- a/tests/test_conflicts_with_enricher.py
+++ b/tests/test_conflicts_with_enricher.py
@@ -1,0 +1,761 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+"""Unit tests for ConflictsWithEnricher."""
+
+import pytest
+
+from scripts.utils.conflicts_with_enricher import (
+    ConflictsWithEnricher,
+    ConflictsWithEnrichmentStats,
+)
+from scripts.utils.extension_constants import X_F5XC_CONFLICTS_WITH
+
+
+@pytest.fixture
+def enricher():
+    """Create enricher instance."""
+    return ConflictsWithEnricher()
+
+
+@pytest.fixture
+def spec_with_two_variant_oneof():
+    """Create a spec with a two-variant OneOf group."""
+    return {
+        "components": {
+            "schemas": {
+                "healthcheckHttpHealthCheck": {
+                    "type": "object",
+                    "x-ves-oneof-field-host_header_choice": [
+                        "host_header",
+                        "use_origin_server_name",
+                    ],
+                    "properties": {
+                        "host_header": {"type": "string"},
+                        "use_origin_server_name": {"type": "object"},
+                        "path": {"type": "string"},
+                    },
+                },
+            },
+        },
+    }
+
+
+@pytest.fixture
+def spec_with_three_variant_oneof():
+    """Create a spec with a three-variant OneOf group."""
+    return {
+        "components": {
+            "schemas": {
+                "appFirewallDetectionSetting": {
+                    "type": "object",
+                    "x-ves-oneof-field-signatures_staging_settings": [
+                        "disable_staging",
+                        "stage_new_and_updated_signatures",
+                        "stage_new_signatures",
+                    ],
+                    "properties": {
+                        "disable_staging": {"type": "object"},
+                        "stage_new_and_updated_signatures": {"type": "object"},
+                        "stage_new_signatures": {"type": "object"},
+                        "other_field": {"type": "string"},
+                    },
+                },
+            },
+        },
+    }
+
+
+@pytest.fixture
+def spec_with_multiple_oneof_groups():
+    """Create a spec with multiple OneOf groups."""
+    return {
+        "components": {
+            "schemas": {
+                "complexSchema": {
+                    "type": "object",
+                    "x-ves-oneof-field-mode_choice": ["blocking", "monitoring"],
+                    "x-ves-oneof-field-detection_choice": [
+                        "default_detection",
+                        "custom_detection",
+                    ],
+                    "properties": {
+                        "blocking": {"type": "object"},
+                        "monitoring": {"type": "object"},
+                        "default_detection": {"type": "object"},
+                        "custom_detection": {"type": "object"},
+                    },
+                },
+            },
+        },
+    }
+
+
+@pytest.fixture
+def spec_with_single_variant():
+    """Create a spec with a single-variant OneOf group (should be skipped)."""
+    return {
+        "components": {
+            "schemas": {
+                "singleVariantSchema": {
+                    "type": "object",
+                    "x-ves-oneof-field-only_choice": ["only_option"],
+                    "properties": {
+                        "only_option": {"type": "object"},
+                    },
+                },
+            },
+        },
+    }
+
+
+@pytest.fixture
+def spec_with_existing_conflicts():
+    """Create a spec with existing x-f5xc-conflicts-with values."""
+    return {
+        "components": {
+            "schemas": {
+                "existingConflictsSchema": {
+                    "type": "object",
+                    "x-ves-oneof-field-choice": ["option_a", "option_b", "option_c"],
+                    "properties": {
+                        "option_a": {
+                            "type": "object",
+                            X_F5XC_CONFLICTS_WITH: ["option_b"],  # Partial existing
+                        },
+                        "option_b": {"type": "object"},
+                        "option_c": {"type": "object"},
+                    },
+                },
+            },
+        },
+    }
+
+
+@pytest.fixture
+def spec_without_schemas():
+    """Create a spec without schemas."""
+    return {
+        "info": {"title": "Empty Spec"},
+        "paths": {},
+    }
+
+
+@pytest.fixture
+def spec_without_properties():
+    """Create a spec with OneOf but no properties."""
+    return {
+        "components": {
+            "schemas": {
+                "noPropertiesSchema": {
+                    "type": "object",
+                    "x-ves-oneof-field-choice": ["a", "b"],
+                },
+            },
+        },
+    }
+
+
+@pytest.fixture
+def spec_with_json_string_oneof():
+    """Create a spec with OneOf extension value as JSON string (as in enriched specs)."""
+    return {
+        "components": {
+            "schemas": {
+                "healthcheckHttpHealthCheck": {
+                    "type": "object",
+                    "x-ves-oneof-field-host_header_choice": '["host_header","use_origin_server_name"]',
+                    "properties": {
+                        "host_header": {"type": "string"},
+                        "use_origin_server_name": {"type": "object"},
+                        "path": {"type": "string"},
+                    },
+                },
+            },
+        },
+    }
+
+
+class TestConflictsWithEnricherBasics:
+    """Test basic enricher functionality."""
+
+    def test_initialization(self):
+        """Test enricher initializes correctly."""
+        enricher = ConflictsWithEnricher()
+        assert enricher is not None
+        assert enricher.stats is not None
+
+    def test_empty_spec(self, enricher):
+        """Test handling of empty spec."""
+        spec = {}
+        result = enricher.enrich_spec(spec)
+        assert result == spec
+        stats = enricher.get_stats()
+        assert stats["schemas_processed"] == 0
+
+    def test_spec_without_schemas(self, enricher, spec_without_schemas):
+        """Test handling of spec without schemas."""
+        result = enricher.enrich_spec(spec_without_schemas)
+        assert result == spec_without_schemas
+        stats = enricher.get_stats()
+        assert stats["schemas_processed"] == 0
+
+
+class TestTwoVariantOneOf:
+    """Test two-variant OneOf group enrichment."""
+
+    def test_enriches_both_variants(self, enricher, spec_with_two_variant_oneof):
+        """Test that both variants get x-f5xc-conflicts-with."""
+        result = enricher.enrich_spec(spec_with_two_variant_oneof)
+
+        schema = result["components"]["schemas"]["healthcheckHttpHealthCheck"]
+        props = schema["properties"]
+
+        # Check host_header has conflicts-with pointing to use_origin_server_name
+        assert X_F5XC_CONFLICTS_WITH in props["host_header"]
+        assert props["host_header"][X_F5XC_CONFLICTS_WITH] == ["use_origin_server_name"]
+
+        # Check use_origin_server_name has conflicts-with pointing to host_header
+        assert X_F5XC_CONFLICTS_WITH in props["use_origin_server_name"]
+        assert props["use_origin_server_name"][X_F5XC_CONFLICTS_WITH] == ["host_header"]
+
+        # Check that non-OneOf properties are unchanged
+        assert X_F5XC_CONFLICTS_WITH not in props["path"]
+
+    def test_statistics_updated(self, enricher, spec_with_two_variant_oneof):
+        """Test that statistics are correctly updated."""
+        enricher.enrich_spec(spec_with_two_variant_oneof)
+        stats = enricher.get_stats()
+
+        assert stats["schemas_processed"] == 1
+        assert stats["schemas_with_oneof"] == 1
+        assert stats["oneof_groups_found"] == 1
+        assert stats["properties_enriched"] == 2
+        assert stats["conflicts_added"] == 2  # Each variant points to 1 other
+
+
+class TestThreeVariantOneOf:
+    """Test three-variant OneOf group enrichment."""
+
+    def test_enriches_all_three_variants(self, enricher, spec_with_three_variant_oneof):
+        """Test that all three variants list the other two."""
+        result = enricher.enrich_spec(spec_with_three_variant_oneof)
+
+        schema = result["components"]["schemas"]["appFirewallDetectionSetting"]
+        props = schema["properties"]
+
+        # Each variant should list the other two (sorted)
+        assert props["disable_staging"][X_F5XC_CONFLICTS_WITH] == [
+            "stage_new_and_updated_signatures",
+            "stage_new_signatures",
+        ]
+        assert props["stage_new_and_updated_signatures"][X_F5XC_CONFLICTS_WITH] == [
+            "disable_staging",
+            "stage_new_signatures",
+        ]
+        assert props["stage_new_signatures"][X_F5XC_CONFLICTS_WITH] == [
+            "disable_staging",
+            "stage_new_and_updated_signatures",
+        ]
+
+        # Non-OneOf field should not have conflicts-with
+        assert X_F5XC_CONFLICTS_WITH not in props["other_field"]
+
+    def test_statistics_for_three_variants(self, enricher, spec_with_three_variant_oneof):
+        """Test statistics for three-variant group."""
+        enricher.enrich_spec(spec_with_three_variant_oneof)
+        stats = enricher.get_stats()
+
+        assert stats["properties_enriched"] == 3
+        # Each of 3 variants lists 2 others = 6 total conflicts
+        assert stats["conflicts_added"] == 6
+
+
+class TestMultipleOneOfGroups:
+    """Test multiple OneOf groups in same schema."""
+
+    def test_enriches_all_groups_independently(
+        self,
+        enricher,
+        spec_with_multiple_oneof_groups,
+    ):
+        """Test that multiple OneOf groups are handled independently."""
+        result = enricher.enrich_spec(spec_with_multiple_oneof_groups)
+
+        schema = result["components"]["schemas"]["complexSchema"]
+        props = schema["properties"]
+
+        # Mode choice group
+        assert props["blocking"][X_F5XC_CONFLICTS_WITH] == ["monitoring"]
+        assert props["monitoring"][X_F5XC_CONFLICTS_WITH] == ["blocking"]
+
+        # Detection choice group
+        assert props["default_detection"][X_F5XC_CONFLICTS_WITH] == ["custom_detection"]
+        assert props["custom_detection"][X_F5XC_CONFLICTS_WITH] == ["default_detection"]
+
+    def test_statistics_for_multiple_groups(
+        self,
+        enricher,
+        spec_with_multiple_oneof_groups,
+    ):
+        """Test statistics for multiple OneOf groups."""
+        enricher.enrich_spec(spec_with_multiple_oneof_groups)
+        stats = enricher.get_stats()
+
+        assert stats["oneof_groups_found"] == 2
+        assert stats["properties_enriched"] == 4
+
+
+class TestEdgeCases:
+    """Test edge cases and special scenarios."""
+
+    def test_single_variant_skipped(self, enricher, spec_with_single_variant):
+        """Test that single-variant groups are skipped."""
+        result = enricher.enrich_spec(spec_with_single_variant)
+
+        schema = result["components"]["schemas"]["singleVariantSchema"]
+        props = schema["properties"]
+
+        # Single variant should not have conflicts-with (nothing to conflict with)
+        assert X_F5XC_CONFLICTS_WITH not in props["only_option"]
+
+        stats = enricher.get_stats()
+        assert stats["oneof_groups_found"] == 0
+
+    def test_preserves_existing_conflicts(self, enricher, spec_with_existing_conflicts):
+        """Test that existing x-f5xc-conflicts-with values are preserved and merged."""
+        result = enricher.enrich_spec(spec_with_existing_conflicts)
+
+        schema = result["components"]["schemas"]["existingConflictsSchema"]
+        props = schema["properties"]
+
+        # option_a had existing ["option_b"], should now have ["option_b", "option_c"]
+        assert X_F5XC_CONFLICTS_WITH in props["option_a"]
+        conflicts = props["option_a"][X_F5XC_CONFLICTS_WITH]
+        assert "option_b" in conflicts
+        assert "option_c" in conflicts
+
+        stats = enricher.get_stats()
+        assert stats["existing_preserved"] == 1
+
+    def test_missing_properties_handled(self, enricher, spec_without_properties):
+        """Test handling of schema with OneOf but no properties."""
+        enricher.enrich_spec(spec_without_properties)
+
+        stats = enricher.get_stats()
+        assert stats["schemas_processed"] == 1
+        # Schema has OneOf groups but no properties to enrich
+        assert stats["schemas_with_oneof"] == 1
+        assert stats["oneof_groups_found"] == 1
+        assert stats["properties_enriched"] == 0  # No properties to enrich
+
+    def test_reset_stats(self, enricher, spec_with_two_variant_oneof):
+        """Test that reset_stats clears all counters."""
+        enricher.enrich_spec(spec_with_two_variant_oneof)
+        assert enricher.get_stats()["schemas_processed"] > 0
+
+        enricher.reset_stats()
+        stats = enricher.get_stats()
+
+        assert stats["schemas_processed"] == 0
+        assert stats["schemas_with_oneof"] == 0
+        assert stats["conflicts_added"] == 0
+
+    def test_handles_json_string_oneof_values(
+        self,
+        enricher,
+        spec_with_json_string_oneof,
+    ):
+        """Test handling of JSON-encoded string values for OneOf extensions."""
+        enriched_spec = enricher.enrich_spec(spec_with_json_string_oneof)
+
+        schema = enriched_spec["components"]["schemas"]["healthcheckHttpHealthCheck"]
+        props = schema["properties"]
+
+        # Should correctly parse JSON string and add conflicts-with
+        assert X_F5XC_CONFLICTS_WITH in props["host_header"]
+        assert props["host_header"][X_F5XC_CONFLICTS_WITH] == ["use_origin_server_name"]
+
+        assert X_F5XC_CONFLICTS_WITH in props["use_origin_server_name"]
+        assert props["use_origin_server_name"][X_F5XC_CONFLICTS_WITH] == ["host_header"]
+
+        # Non-OneOf field should not have conflicts-with
+        assert X_F5XC_CONFLICTS_WITH not in props["path"]
+
+        stats = enricher.get_stats()
+        assert stats["schemas_with_oneof"] == 1
+        assert stats["properties_enriched"] == 2
+
+
+class TestStatisticsDataclass:
+    """Test ConflictsWithEnrichmentStats dataclass."""
+
+    def test_stats_to_dict(self):
+        """Test statistics conversion to dictionary."""
+        stats = ConflictsWithEnrichmentStats(
+            schemas_processed=10,
+            schemas_with_oneof=5,
+            oneof_groups_found=8,
+            conflicts_added=20,
+            properties_enriched=16,
+            existing_preserved=2,
+        )
+
+        result = stats.to_dict()
+
+        assert result["schemas_processed"] == 10
+        assert result["schemas_with_oneof"] == 5
+        assert result["oneof_groups_found"] == 8
+        assert result["conflicts_added"] == 20
+        assert result["properties_enriched"] == 16
+        assert result["existing_preserved"] == 2
+        assert result["error_count"] == 0
+
+    def test_stats_with_errors(self):
+        """Test statistics with errors."""
+        stats = ConflictsWithEnrichmentStats(
+            errors=[{"schema": "TestSchema", "error": "Test error"}],
+        )
+
+        result = stats.to_dict()
+
+        assert result["error_count"] == 1
+        assert len(result["errors"]) == 1
+
+
+class TestIntegrationScenarios:
+    """Test integration-like scenarios with realistic spec structures."""
+
+    def test_healthcheck_example_from_issue(self, enricher):
+        """Test the healthcheck example from Issue #494."""
+        spec = {
+            "components": {
+                "schemas": {
+                    "healthcheckHttpHealthCheck": {
+                        "type": "object",
+                        "x-ves-oneof-field-host_header_choice": [
+                            "host_header",
+                            "use_origin_server_name",
+                        ],
+                        "properties": {
+                            "host_header": {
+                                "type": "string",
+                                "description": "Host header to use",
+                            },
+                            "use_origin_server_name": {
+                                "type": "object",
+                                "description": "Use origin server name",
+                            },
+                            "path": {
+                                "type": "string",
+                                "description": "Health check path",
+                            },
+                            "timeout": {
+                                "type": "integer",
+                                "description": "Timeout in seconds",
+                            },
+                        },
+                    },
+                },
+            },
+        }
+
+        result = enricher.enrich_spec(spec)
+
+        props = result["components"]["schemas"]["healthcheckHttpHealthCheck"]["properties"]
+
+        # Verify the exact output format from the issue
+        assert props["host_header"][X_F5XC_CONFLICTS_WITH] == ["use_origin_server_name"]
+        assert props["use_origin_server_name"][X_F5XC_CONFLICTS_WITH] == ["host_header"]
+
+        # Verify non-OneOf fields are unchanged
+        assert X_F5XC_CONFLICTS_WITH not in props["path"]
+        assert X_F5XC_CONFLICTS_WITH not in props["timeout"]
+
+    def test_app_firewall_multiple_groups(self, enricher):
+        """Test realistic app_firewall schema with multiple OneOf groups."""
+        spec = {
+            "components": {
+                "schemas": {
+                    "appFirewallCreateSpecType": {
+                        "type": "object",
+                        "x-ves-oneof-field-enforcement_mode_choice": [
+                            "blocking",
+                            "monitoring",
+                        ],
+                        "x-ves-oneof-field-detection_setting_choice": [
+                            "ai_risk_based_blocking",
+                            "default_detection_settings",
+                            "detection_settings",
+                        ],
+                        "properties": {
+                            "blocking": {"type": "object"},
+                            "monitoring": {"type": "object"},
+                            "ai_risk_based_blocking": {"type": "object"},
+                            "default_detection_settings": {"type": "object"},
+                            "detection_settings": {"type": "object"},
+                            "name": {"type": "string"},
+                        },
+                    },
+                },
+            },
+        }
+
+        result = enricher.enrich_spec(spec)
+
+        props = result["components"]["schemas"]["appFirewallCreateSpecType"]["properties"]
+
+        # Enforcement mode group
+        assert props["blocking"][X_F5XC_CONFLICTS_WITH] == ["monitoring"]
+        assert props["monitoring"][X_F5XC_CONFLICTS_WITH] == ["blocking"]
+
+        # Detection setting group (3 variants)
+        assert set(props["ai_risk_based_blocking"][X_F5XC_CONFLICTS_WITH]) == {
+            "default_detection_settings",
+            "detection_settings",
+        }
+        assert set(props["default_detection_settings"][X_F5XC_CONFLICTS_WITH]) == {
+            "ai_risk_based_blocking",
+            "detection_settings",
+        }
+        assert set(props["detection_settings"][X_F5XC_CONFLICTS_WITH]) == {
+            "ai_risk_based_blocking",
+            "default_detection_settings",
+        }
+
+        # Name should not be affected
+        assert X_F5XC_CONFLICTS_WITH not in props["name"]
+
+
+class TestAcceptance:
+    """Acceptance tests verifying end-to-end behavior with real-world patterns.
+
+    These tests verify the enricher works correctly with schema patterns
+    found in the actual F5 XC API specifications after pipeline processing.
+    """
+
+    def test_accepts_json_string_values_from_pipeline(self, enricher):
+        """Acceptance: Enricher handles JSON-encoded values from pipeline output.
+
+        The F5 XC pipeline stores x-ves-oneof-field-* values as JSON strings
+        (e.g., '["host_header","use_origin_server_name"]'). The enricher must
+        parse these correctly.
+        """
+        # Real-world pattern from virtual.json after pipeline processing
+        spec = {
+            "components": {
+                "schemas": {
+                    "healthcheckHttpHealthCheck": {
+                        "type": "object",
+                        "description": "HTTP Health Check configuration",
+                        "x-displayname": "HTTP Health Check.",
+                        "x-ves-oneof-field-host_header_choice": '["host_header","use_origin_server_name"]',
+                        "x-ves-proto-message": "ves.io.schema.healthcheck.HttpHealthCheck",
+                        "properties": {
+                            "host_header": {
+                                "type": "string",
+                                "x-displayname": "Host Header Value.",
+                            },
+                            "use_origin_server_name": {
+                                "type": "object",
+                                "x-f5xc-server-default": True,
+                            },
+                            "path": {
+                                "type": "string",
+                                "x-ves-required": "true",
+                            },
+                        },
+                    },
+                },
+            },
+        }
+
+        result = enricher.enrich_spec(spec)
+        props = result["components"]["schemas"]["healthcheckHttpHealthCheck"]["properties"]
+
+        # Acceptance criteria: Both variants have bidirectional conflicts
+        assert props["host_header"][X_F5XC_CONFLICTS_WITH] == ["use_origin_server_name"]
+        assert props["use_origin_server_name"][X_F5XC_CONFLICTS_WITH] == ["host_header"]
+
+        # Acceptance criteria: Existing extensions preserved
+        assert props["host_header"]["x-displayname"] == "Host Header Value."
+        assert props["use_origin_server_name"]["x-f5xc-server-default"] is True
+        assert props["path"]["x-ves-required"] == "true"
+
+    def test_accepts_multiple_oneof_groups_in_single_schema(self, enricher):
+        """Acceptance: Enricher handles schemas with 5+ OneOf groups.
+
+        Real app_firewall schemas have many OneOf groups. Each group must
+        be processed independently without cross-contamination.
+        """
+        spec = {
+            "components": {
+                "schemas": {
+                    "appFirewallCreateSpecType": {
+                        "type": "object",
+                        # 6 OneOf groups (realistic count for app_firewall)
+                        "x-ves-oneof-field-enforcement_mode_choice": '["blocking","monitoring"]',
+                        "x-ves-oneof-field-detection_setting_choice": '["ai_risk_based_blocking","default_detection_settings","detection_settings"]',
+                        "x-ves-oneof-field-blocking_page_choice": '["blocking_page","use_default_blocking_page"]',
+                        "x-ves-oneof-field-bot_protection_choice": '["bot_protection_setting","default_bot_setting"]',
+                        "x-ves-oneof-field-anonymization_setting": '["custom_anonymization","default_anonymization","disable_anonymization"]',
+                        "x-ves-oneof-field-allowed_response_codes_choice": '["allow_all_response_codes","allowed_response_codes"]',
+                        "properties": {
+                            # Enforcement mode group
+                            "blocking": {"type": "object"},
+                            "monitoring": {"type": "object"},
+                            # Detection setting group
+                            "ai_risk_based_blocking": {"type": "object"},
+                            "default_detection_settings": {"type": "object"},
+                            "detection_settings": {"type": "object"},
+                            # Blocking page group
+                            "blocking_page": {"type": "object"},
+                            "use_default_blocking_page": {"type": "object"},
+                            # Bot protection group
+                            "bot_protection_setting": {"type": "object"},
+                            "default_bot_setting": {"type": "object"},
+                            # Anonymization group
+                            "custom_anonymization": {"type": "object"},
+                            "default_anonymization": {"type": "object"},
+                            "disable_anonymization": {"type": "object"},
+                            # Response codes group
+                            "allow_all_response_codes": {"type": "object"},
+                            "allowed_response_codes": {"type": "object"},
+                            # Non-OneOf field
+                            "name": {"type": "string"},
+                        },
+                    },
+                },
+            },
+        }
+
+        result = enricher.enrich_spec(spec)
+        props = result["components"]["schemas"]["appFirewallCreateSpecType"]["properties"]
+        stats = enricher.get_stats()
+
+        # Acceptance criteria: 6 OneOf groups found
+        assert stats["oneof_groups_found"] == 6
+
+        # Acceptance criteria: No cross-group contamination
+        # blocking should only conflict with monitoring (same group)
+        assert props["blocking"][X_F5XC_CONFLICTS_WITH] == ["monitoring"]
+        assert "ai_risk_based_blocking" not in props["blocking"][X_F5XC_CONFLICTS_WITH]
+
+        # detection_settings should only conflict with other detection options
+        assert set(props["detection_settings"][X_F5XC_CONFLICTS_WITH]) == {
+            "ai_risk_based_blocking",
+            "default_detection_settings",
+        }
+        assert "blocking" not in props["detection_settings"][X_F5XC_CONFLICTS_WITH]
+
+        # 3-variant group should have 2 conflicts each
+        assert len(props["custom_anonymization"][X_F5XC_CONFLICTS_WITH]) == 2
+        assert len(props["default_anonymization"][X_F5XC_CONFLICTS_WITH]) == 2
+        assert len(props["disable_anonymization"][X_F5XC_CONFLICTS_WITH]) == 2
+
+        # Non-OneOf field should be untouched
+        assert X_F5XC_CONFLICTS_WITH not in props["name"]
+
+    def test_accepts_large_spec_with_many_schemas(self, enricher):
+        """Acceptance: Enricher handles specs with 100+ schemas efficiently.
+
+        Real domain specs (like virtual.json) have 700+ schemas. The enricher
+        must process these without errors and track accurate statistics.
+        """
+        # Generate a spec with 150 schemas, some with OneOf groups
+        schemas = {}
+        oneof_count = 0
+        for i in range(150):
+            if i % 3 == 0:  # Every 3rd schema has a OneOf group
+                schemas[f"Schema{i}"] = {
+                    "type": "object",
+                    "x-ves-oneof-field-choice": f'["option_a_{i}","option_b_{i}"]',
+                    "properties": {
+                        f"option_a_{i}": {"type": "object"},
+                        f"option_b_{i}": {"type": "object"},
+                        "other_field": {"type": "string"},
+                    },
+                }
+                oneof_count += 1
+            else:
+                schemas[f"Schema{i}"] = {
+                    "type": "object",
+                    "properties": {
+                        "field1": {"type": "string"},
+                        "field2": {"type": "integer"},
+                    },
+                }
+
+        spec = {"components": {"schemas": schemas}}
+
+        enricher.enrich_spec(spec)
+        stats = enricher.get_stats()
+
+        # Acceptance criteria: All schemas processed
+        assert stats["schemas_processed"] == 150
+
+        # Acceptance criteria: Correct number of OneOf schemas identified
+        assert stats["schemas_with_oneof"] == oneof_count
+
+        # Acceptance criteria: All OneOf groups found (50 schemas x 1 group each)
+        assert stats["oneof_groups_found"] == oneof_count
+
+        # Acceptance criteria: Correct number of properties enriched (50 schemas x 2 variants)
+        assert stats["properties_enriched"] == oneof_count * 2
+
+        # Acceptance criteria: No errors
+        assert stats["error_count"] == 0
+
+    def test_accepts_spec_and_produces_terraform_compatible_output(self, enricher):
+        """Acceptance: Output format is compatible with Terraform provider consumption.
+
+        The x-f5xc-conflicts-with extension must be an array of strings that
+        Terraform providers can use for ConflictsWith validation rules.
+        """
+        spec = {
+            "components": {
+                "schemas": {
+                    "originPoolCreateSpecType": {
+                        "type": "object",
+                        "x-ves-oneof-field-origin_server_type": '["public_ip","public_name","k8s_service","consul_service","private_ip","custom_endpoint"]',
+                        "properties": {
+                            "public_ip": {"type": "object"},
+                            "public_name": {"type": "object"},
+                            "k8s_service": {"type": "object"},
+                            "consul_service": {"type": "object"},
+                            "private_ip": {"type": "object"},
+                            "custom_endpoint": {"type": "object"},
+                        },
+                    },
+                },
+            },
+        }
+
+        result = enricher.enrich_spec(spec)
+        props = result["components"]["schemas"]["originPoolCreateSpecType"]["properties"]
+
+        # Acceptance criteria for Terraform compatibility:
+        for prop_name in [
+            "public_ip",
+            "public_name",
+            "k8s_service",
+            "consul_service",
+            "private_ip",
+            "custom_endpoint",
+        ]:
+            conflicts = props[prop_name].get(X_F5XC_CONFLICTS_WITH)
+
+            # 1. Must be a list
+            assert isinstance(conflicts, list), f"{prop_name} conflicts-with is not a list"
+
+            # 2. Must contain strings only (Terraform resource attribute names)
+            for item in conflicts:
+                assert isinstance(item, str), f"{prop_name} contains non-string: {item}"
+
+            # 3. Must not include self
+            assert prop_name not in conflicts, f"{prop_name} conflicts with itself"
+
+            # 4. Must list all OTHER variants (5 others in a 6-variant group)
+            assert len(conflicts) == 5, f"{prop_name} should have 5 conflicts, got {len(conflicts)}"
+
+            # 5. Must be sorted for deterministic output
+            assert conflicts == sorted(conflicts), f"{prop_name} conflicts not sorted"


### PR DESCRIPTION
## Summary

Add support for declaring mutual exclusivity relationships between OneOf group members via the new `x-f5xc-conflicts-with` extension. This allows downstream tools to validate field conflicts at the schema level rather than at runtime.

## Changes

- **New Extension**: `x-f5xc-conflicts-with` (array of strings)
  - Auto-derived from `x-ves-oneof-field-*` extensions during enrichment
  - Declares which properties cannot be used together
  - Enables schema-level validation in downstream tools

- **New Enricher**: `ConflictsWithEnricher` class
  - Inspects native `x-ves-oneof-field-*` extensions
  - Auto-derives mutual exclusivity relationships
  - Adds `x-f5xc-conflicts-with` to each OneOf group member

- **Pipeline Integration**:
  - Integrated into main enrichment pipeline
  - Tracks conflicts added in pipeline statistics
  - Includes metrics in summary report and JSON output

- **Documentation**:
  - Updated DEVELOPMENT.md with complete extension reference
  - Added OneOf extension comparison table
  - Included use cases and schema examples

## Impact

- **Terraform**: Providers can generate validation rules preventing conflicting fields
- **CLI**: Tools can warn about incompatible field combinations  
- **MCP**: Assistants can provide conflict-aware schema analysis
- **IDE**: Extensions can offer intelligent autocompletion avoiding conflicts
- **AI Assistants**: Can generate correct OneOf configurations automatically

## Testing

20 comprehensive test cases covering:
- Basic conflict detection and enrichment
- Multiple OneOf variants in single schema
- Preservation of existing conflict metadata
- JSON-encoded extension values
- Large-scale acceptance criteria (150 schemas)
- Terraform-compatible output format

Closes #494