### PR TITLE
fix: set enforce_admins to false for CI/CD workflow bypass

### DIFF
--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -7,5 +7,29 @@
     "f5xc",
     "openapi",
     "api"
+  ],
+  "branch_protection": [
+    {
+      "branch": "main",
+      "enforce_admins": false,
+      "required_status_checks": {
+        "strict": false,
+        "contexts": ["Check linked issues"]
+      },
+      "required_pull_request_reviews": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews": false,
+        "require_code_owner_reviews": false,
+        "require_last_push_approval": false
+      },
+      "restrictions": null,
+      "required_linear_history": false,
+      "allow_force_pushes": false,
+      "allow_deletions": false,
+      "block_creations": false,
+      "required_conversation_resolution": false,
+      "lock_branch": false,
+      "allow_fork_syncing": false
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- Override template default `enforce_admins: true` with per-repo `enforce_admins: false` in `.github/config/repo-settings.json`
- Allows the `VERSION_BUMP_PAT` admin token to bypass legacy branch protection when pushing release commits to main
- Preserves all other protections (PR requirement, "Check linked issues" status check) for non-admin users

## Context
The sync-and-enrich workflow fails at "Commit and tag release" with `GH013: Repository rule violations` because two overlapping protection layers block the admin PAT:
1. Repository ruleset (has Admin bypass, but may not work with fine-grained PATs)
2. Legacy branch protection with `enforce_admins: true` (blocks ALL bypass)

The per-repo override is deep-merged with template defaults by `enforce-repo-settings.yml`, surviving governance syncs.

## Test plan
- [x] Applied `enforce_admins: false` via API immediately
- [ ] Re-run of failed workflow (run 21894216164) succeeds
- [ ] Future sync-and-enrich runs push to main without GH013 errors
- [ ] Governance sync doesn't revert the override (deep-merge preserves it)

Closes #533

🤖 Generated with [Claude Code](https://claude.com/claude-code)