### PR TITLE
feat: replace iframe with inline Scalar component in MDX wrappers

### DIFF
--- a/scripts/generate_api_viewer.py
+++ b/scripts/generate_api_viewer.py
@@ -75,6 +75,7 @@ sidebar:
 ---
 
 import {{ LinkCard }} from '@astrojs/starlight/components';
+import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
 
 <div style="margin-bottom: 1rem; display: flex; gap: 0.5rem; flex-wrap: wrap;">
   <LinkCard title="Back to API Catalog" href="/api-reference/" />
@@ -82,12 +83,7 @@ import {{ LinkCard }} from '@astrojs/starlight/components';
   <LinkCard title="Download Spec" href="{spec_path}" />
 </div>
 
-<iframe
-  src="{viewer_path}"
-  style="width: 100%; height: 80vh; border: 1px solid var(--sl-color-gray-5); border-radius: 0.5rem;"
-  title="{title} API Reference"
-  loading="lazy"
-/>
+<ScalarViewer specUrl="{spec_path}" title="{title}" />
 """
 
 


### PR DESCRIPTION
## Summary
- Update `generate_domain_mdx()` to import `ScalarApiViewerWrapper.astro` via `@components/` alias
- Replace `<iframe>` with `<ScalarViewer specUrl="..." title="..." />` component
- Standalone HTML viewers and "Full Screen" link preserved as fallback
- Catalog index page unchanged

**Depends on**: robinmordasiewicz/f5xc-docs-builder#110

## Test plan
- [ ] Run `python -m scripts.generate_api_viewer` and inspect generated MDX for correct import/component usage
- [ ] Build with updated Docker container and verify API domains render inline
- [ ] Verify Full Screen link still navigates to standalone HTML viewer
- [ ] Confirm catalog index page is unaffected

Closes #552

🤖 Generated with [Claude Code](https://claude.com/claude-code)