### PR TITLE
test: verify workflow cache-hit path on non-pipeline push

### DIFF
--- a/scripts/generate_api_viewer.py
+++ b/scripts/generate_api_viewer.py
@@ -3,6 +3,9 @@
 
 """Generate Scalar API viewer pages and Starlight MDX wrappers.
 
+# Cache-hit verification: this comment triggers the workflow via scripts/** path
+# but does NOT invalidate the enriched cache (this file is excluded from the key).
+
 Reads docs/specifications/api/index.json and generates:
   - docs/specifications/api/viewer/{domain}.html  (standalone Scalar viewers)
   - docs/api-reference/{domain}.mdx               (Starlight iframe wrappers)


### PR DESCRIPTION
## Summary

- Add a comment to `scripts/generate_api_viewer.py` to trigger the workflow via `scripts/**` path filter
- This file is excluded from the enriched cache key, so both specs and enriched caches should HIT
- Verification test for #558

## Test plan

- [ ] Confirm specs cache HIT in workflow logs
- [ ] Confirm enriched cache HIT in workflow logs
- [ ] Confirm "Install Java" and "Run enrichment pipeline" show as skipped
- [ ] Confirm "Generate API viewer pages" still runs

Closes #560

🤖 Generated with [Claude Code](https://claude.com/claude-code)