### PR TITLE
fix: replace unstable hashFiles with explicit pipeline fingerprint

### DIFF
--- a/.github/workflows/sync-and-enrich.yml
+++ b/.github/workflows/sync-and-enrich.yml
@@ -145,13 +145,26 @@ jobs:
           HASH=$(find specs/original -name '*.json' -type f -exec sha256sum {} + | sort | sha256sum | cut -d' ' -f1)
           echo "hash=$HASH" >> "$GITHUB_OUTPUT"
 
+      - name: Compute pipeline code fingerprint
+        id: pipeline-fingerprint
+        run: |
+          HASH=$(cat \
+            scripts/pipeline.py \
+            scripts/merge_specs.py \
+            scripts/enrich.py \
+            scripts/normalize.py \
+            requirements.txt \
+            $(find scripts/utils scripts/discovery config -type f 2>/dev/null | sort) \
+            | sha256sum | cut -d' ' -f1)
+          echo "hash=$HASH" >> "$GITHUB_OUTPUT"
+
       - name: Restore enriched output cache
         if: github.event_name != 'workflow_dispatch'
         id: enriched-cache
         uses: actions/cache/restore@v4
         with:
           path: docs/specifications/api
-          key: enriched-${{ steps.specs-fingerprint.outputs.hash }}-${{ hashFiles('scripts/pipeline.py', 'scripts/merge_specs.py', 'scripts/enrich.py', 'scripts/normalize.py', 'scripts/utils/**', 'scripts/discovery/**', 'config/**', 'requirements.txt') }}
+          key: enriched-${{ steps.specs-fingerprint.outputs.hash }}-${{ steps.pipeline-fingerprint.outputs.hash }}
 
       - name: Install Java (for LanguageTool)
         if: steps.enriched-cache.outputs.cache-hit != 'true'
@@ -202,7 +215,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: docs/specifications/api
-          key: enriched-${{ steps.specs-fingerprint.outputs.hash }}-${{ hashFiles('scripts/pipeline.py', 'scripts/merge_specs.py', 'scripts/enrich.py', 'scripts/normalize.py', 'scripts/utils/**', 'scripts/discovery/**', 'config/**', 'requirements.txt') }}
+          key: enriched-${{ steps.specs-fingerprint.outputs.hash }}-${{ steps.pipeline-fingerprint.outputs.hash }}
 
       - name: Generate API viewer pages
         run: python -m scripts.generate_api_viewer

--- a/scripts/generate_api_viewer.py
+++ b/scripts/generate_api_viewer.py
@@ -3,9 +3,6 @@
 
 """Generate Scalar API viewer pages and Starlight MDX wrappers.
 
-# Cache-hit verification: this comment triggers the workflow via scripts/** path
-# but does NOT invalidate the enriched cache (this file is excluded from the key).
-
 Reads docs/specifications/api/index.json and generates:
   - docs/specifications/api/viewer/{domain}.html  (standalone Scalar viewers)
   - docs/api-reference/{domain}.mdx               (Starlight iframe wrappers)


### PR DESCRIPTION
## Summary

- Replace `hashFiles()` with explicit `sha256sum` computation for the enriched cache key
- `hashFiles()` evaluates against the workspace at step expression time — if `pip install` writes `.pyc` files or the pipeline modifies files in tracked paths, the hash changes mid-run, causing the enriched cache to never hit
- New approach: dedicated shell step computes pipeline code fingerprint once on a clean checkout, producing a stable hash
- Also removes the test comment from `generate_api_viewer.py`

## Root cause

Confirmed via workflow logs (run 21916731436):
- Restore key: `enriched-c79b7aac...-ce1d537c...`
- Saved cache: `enriched-c79b7aac...-306888af...`
- Even within the SAME run, restore and save had different `hashFiles()` values

## Test plan

- [ ] After merge, this push triggers the workflow — first run will populate the new cache
- [ ] Next push to a non-pipeline file should show enriched cache HIT and pipeline skipped

Closes #562

🤖 Generated with [Claude Code](https://claude.com/claude-code)