### PR TITLE
test: verify enriched cache hit after hashFiles fix

### DIFF
--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+# Spectral-based linting for enriched OpenAPI specifications.
 
 """Lint OpenAPI specifications using Spectral.
 


### PR DESCRIPTION
## Summary

- Add a comment to `scripts/lint.py` to trigger the workflow via `scripts/**` path
- `lint.py` is NOT in the pipeline fingerprint, so both caches should HIT
- Verifies the fix from #562 works correctly

## Expected behavior

- Specs cache: HIT (download skipped)
- Enriched cache: HIT (Java install, pipeline, constraint analysis all skipped)
- Generate API viewer pages: runs normally

Closes #564

🤖 Generated with [Claude Code](https://claude.com/claude-code)