### PR TITLE
chore: remove test comment from lint.py

### DIFF
--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 # Copyright (c) 2026 Robin Mordasiewicz. MIT License.
-# Spectral-based linting for enriched OpenAPI specifications.
 
 """Lint OpenAPI specifications using Spectral.
 


### PR DESCRIPTION
## Summary

- Remove the test comment added to `scripts/lint.py` during cache-hit verification (#564)
- The test succeeded and the comment is no longer needed

Closes #566

🤖 Generated with [Claude Code](https://claude.com/claude-code)